### PR TITLE
refactor: peaks panel

### DIFF
--- a/src/component/context/EventContext.tsx
+++ b/src/component/context/EventContext.tsx
@@ -1,0 +1,116 @@
+import { Draft, produce } from 'immer';
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useCallback,
+  useReducer,
+  ReactElement,
+  ReactFragment,
+} from 'react';
+
+type CallBackFun = (data?: any) => void;
+interface EventState {
+  callbackLists: { [eventName: string]: CallBackFun };
+}
+
+export interface EventContext {
+  on: (eventName: string, handler: CallBackFun) => void;
+  trigger: (eventName: string, data?: any) => void;
+  clean: (eventName: string | string[]) => void;
+}
+
+type ActionType<Action, Payload = void> = Payload extends void
+  ? { type: Action }
+  : { type: Action; payload: Payload };
+
+type PreferencesActions =
+  | ActionType<'ON', { eventName: string; handler: CallBackFun }>
+  | ActionType<'CLEAN', { eventNames: string | string[] }>;
+
+const initState: EventState = {
+  callbackLists: {},
+};
+
+const reducer = produce(
+  (draft: Draft<EventState>, action: PreferencesActions) => {
+    switch (action.type) {
+      case 'ON': {
+        const { eventName, handler } = action.payload;
+        if (!draft.callbackLists[eventName]) {
+          draft.callbackLists[eventName] = handler;
+        }
+        return draft;
+      }
+      case 'CLEAN': {
+        const { eventNames } = action.payload;
+        const names = Array.isArray(eventNames) ? eventNames : [eventNames];
+        draft.callbackLists = Object.entries(draft.callbackLists)
+          .filter(([key]) => !names.includes(key))
+          .reduce((acc, [eventName, func]) => (acc[eventName] = func), {});
+        return draft;
+      }
+
+      default: {
+        return draft;
+      }
+    }
+  },
+);
+
+const eventContext = createContext<EventContext | null>(null);
+
+export function useEventContext(): EventContext {
+  const context = useContext(eventContext);
+  if (!context) {
+    throw new Error('Event context  was not found');
+  }
+
+  return context;
+}
+
+type ChildrenNodes =
+  | ReactElement<any>
+  | Array<ReactElement<any>>
+  | ReactFragment
+  | boolean
+  | null;
+
+export function EventContextProvider(props: {
+  children: ChildrenNodes | ((state: EventContext) => ChildrenNodes);
+}) {
+  const [events, dispatch] = useReducer(reducer, initState);
+
+  const onHandler = useCallback((eventName: string, handler: CallBackFun) => {
+    dispatch({ type: 'ON', payload: { eventName, handler } });
+  }, []);
+
+  const triggerHandler = useCallback(
+    (eventName: string, data?: any) => {
+      if (events.callbackLists[eventName]) {
+        events.callbackLists[eventName](data);
+      }
+    },
+    [events.callbackLists],
+  );
+  const cleanHandler = useCallback((eventNames: string | string[]) => {
+    dispatch({ type: 'CLEAN', payload: { eventNames } });
+  }, []);
+
+  const state = useMemo(
+    () => ({
+      on: onHandler,
+      trigger: triggerHandler,
+      clean: cleanHandler,
+    }),
+    [cleanHandler, onHandler, triggerHandler],
+  );
+
+  return (
+    <eventContext.Provider value={state}>
+      {typeof props.children === 'function'
+        ? props.children?.(state)
+        : props.children}
+    </eventContext.Provider>
+  );
+}

--- a/src/component/elements/SwitchContainer/SwitchContainerContext.tsx
+++ b/src/component/elements/SwitchContainer/SwitchContainerContext.tsx
@@ -1,0 +1,51 @@
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useMemo,
+  useCallback,
+  useState,
+} from 'react';
+
+export interface SwitchContext {
+  isFlipped: boolean;
+  open: (event?) => void;
+  close: (event?, extra?: any) => void;
+}
+
+export const SwitchContainerContext = createContext<SwitchContext | null>(null);
+
+export function useSwitchContext(): SwitchContext {
+  const context = useContext(SwitchContainerContext);
+  if (!context) {
+    throw new Error('Switch context was not found');
+  }
+  return context;
+}
+
+export function SwitchContainerProvider(props: { children: ReactNode }) {
+  const [isFlipped, setFlipped] = useState<boolean>(false);
+
+  const openHandler = useCallback(() => {
+    setFlipped(true);
+  }, [setFlipped]);
+
+  const closeHandler = useCallback(() => {
+    setFlipped(false);
+  }, [setFlipped]);
+
+  const state = useMemo(
+    () => ({
+      isFlipped,
+      open: openHandler,
+      close: closeHandler,
+    }),
+    [closeHandler, isFlipped, openHandler],
+  );
+
+  return (
+    <SwitchContainerContext.Provider value={state}>
+      {props.children}
+    </SwitchContainerContext.Provider>
+  );
+}

--- a/src/component/elements/SwitchContainer/SwitchContainerContext.tsx
+++ b/src/component/elements/SwitchContainer/SwitchContainerContext.tsx
@@ -9,8 +9,8 @@ import {
 
 export interface SwitchContext {
   isFlipped: boolean;
-  open: (event?) => void;
-  close: (event?, extra?: any) => void;
+  open: () => void;
+  close: () => void;
 }
 
 export const SwitchContainerContext = createContext<SwitchContext | null>(null);

--- a/src/component/elements/SwitchContainer/index.tsx
+++ b/src/component/elements/SwitchContainer/index.tsx
@@ -1,0 +1,49 @@
+/** @jsxImportSource @emotion/react */
+import { ReactElement, ReactFragment } from 'react';
+
+import { tablePanelStyle } from '../../panels/extra/BasicPanelStyle';
+
+import {
+  SwitchContainerProvider,
+  SwitchContext,
+  useSwitchContext,
+} from './SwitchContainerContext';
+
+type InnerChildren =
+  | ReactElement<any>
+  | ((state: SwitchContext) => ReactElement<any>);
+
+type ChildrenNodes =
+  | ReactElement<any>
+  | Array<ReactElement<any>>
+  | ReactFragment
+  | boolean
+  | null;
+
+export function SwitchContainer(props: { children: ChildrenNodes }) {
+  return (
+    <SwitchContainerProvider>
+      <div css={tablePanelStyle}>{props.children}</div>
+    </SwitchContainerProvider>
+  );
+}
+
+SwitchContainer.Front = function FrontContainer(props: {
+  children: InnerChildren;
+}) {
+  return <ContainerItem flag={false}>{props.children}</ContainerItem>;
+};
+SwitchContainer.Back = function BackContainer(props: {
+  children: InnerChildren;
+}) {
+  return <ContainerItem flag>{props.children}</ContainerItem>;
+};
+
+function ContainerItem(props: { children: InnerChildren; flag: boolean }) {
+  const context = useSwitchContext();
+  return context.isFlipped === props.flag
+    ? typeof props.children === 'function'
+      ? props.children?.(context)
+      : props.children
+    : null;
+}

--- a/src/component/panels/PeaksPanel/PeaksPanel.tsx
+++ b/src/component/panels/PeaksPanel/PeaksPanel.tsx
@@ -104,7 +104,6 @@ function PeaksPanelInner({
               onSettingClick={open}
             />
             <PeaksTable
-              className="inner-container"
               data={filteredPeaks}
               activeTab={activeTab}
               preferences={preferences}

--- a/src/component/panels/PeaksPanel/PeaksTable.tsx
+++ b/src/component/panels/PeaksPanel/PeaksTable.tsx
@@ -25,9 +25,16 @@ interface PeaksTableProps {
   info: {
     nucleus: string;
   };
+  className?: string;
 }
 
-function PeaksTable({ activeTab, preferences, data, info }: PeaksTableProps) {
+function PeaksTable({
+  activeTab,
+  preferences,
+  data,
+  info,
+  className,
+}: PeaksTableProps) {
   const dispatch = useDispatch();
   const format = useFormatNumberByNucleus(info.nucleus);
 
@@ -155,6 +162,7 @@ function PeaksTable({ activeTab, preferences, data, info }: PeaksTableProps) {
 
   return data && data.length > 0 ? (
     <ReactTable
+      className={className}
       data={data}
       columns={tableColumns}
       approxItemHeight={20}

--- a/src/component/panels/PeaksPanel/PeaksTable.tsx
+++ b/src/component/panels/PeaksPanel/PeaksTable.tsx
@@ -25,16 +25,9 @@ interface PeaksTableProps {
   info: {
     nucleus: string;
   };
-  className?: string;
 }
 
-function PeaksTable({
-  activeTab,
-  preferences,
-  data,
-  info,
-  className,
-}: PeaksTableProps) {
+function PeaksTable({ activeTab, preferences, data, info }: PeaksTableProps) {
   const dispatch = useDispatch();
   const format = useFormatNumberByNucleus(info.nucleus);
 
@@ -162,7 +155,6 @@ function PeaksTable({
 
   return data && data.length > 0 ? (
     <ReactTable
-      className={className}
       data={data}
       columns={tableColumns}
       approxItemHeight={20}


### PR DESCRIPTION
In the past, we use the ref to invoke a function inside the preferences panel once we press the save button and then we hide the panel by switching the flag, I use this way because the two components are siblings and Flipped state in their parent component. 
```
const [isFlipped,setFlipped] = useState(false);
<Panel>
  <Preferences>
    <header onSave={handleSavePreferences} onClose={handleClosePreferences} />
    <body ref />
  </Preferences>
  <Peaks>
    <header onSetting= {handeOpenPreferences} />
    <body />
  </Peaks>
</panel>
```


what I'm trying answers on in this PR if we have two siblings, how we can invoke a function in the second one for an event triggered from the first sibling without moving the state and handler to the upper level, the second thing create a reusable component to switch between panels



