### PR TITLE
feat: generate blob for the spectra from an outside component

### DIFF
--- a/src/component/NMRium.tsx
+++ b/src/component/NMRium.tsx
@@ -165,7 +165,7 @@ const defaultData: NMRiumData = {
 };
 
 export interface NMRiumRef {
-  generateBlob: () => BlobObject | null;
+  getSpectraViewerAsBlob: () => BlobObject | null;
 }
 
 const NMRium = forwardRef<NMRiumRef, NMRiumProps>(function NMRium(props, ref) {
@@ -239,7 +239,7 @@ function InnerNMRium({
   useImperativeHandle(
     innerRef,
     () => ({
-      generateBlob: () => {
+      getSpectraViewerAsBlob: () => {
         return rootRef?.current ? getBlob(rootRef.current, 'nmrSVG') : null;
       },
     }),

--- a/src/component/utility/Export.ts
+++ b/src/component/utility/Export.ts
@@ -134,6 +134,7 @@ function exportAsMol(data, fileName = 'mol') {
 /**
  * export the vitalization result as SVG, if you need to remove some content during exportation process enclose the the content with <!-- export-remove --> ${content} <!-- export-remove -->
  */
+
 function exportAsSVG(
   rootRef: HTMLDivElement,
   elementID: string,
@@ -251,12 +252,18 @@ function copyPNGToClipboard(rootRef: HTMLDivElement, elementID: string) {
   }
 }
 
-function getBlob(rootRef: HTMLDivElement, elementID: string) {
+export interface BlobObject {
+  blob: Blob;
+  width: number;
+  height: number;
+}
+
+function getBlob(rootRef: HTMLDivElement, elementID: string): BlobObject {
   let _svg: any = (rootRef.getRootNode() as Document)
     .getElementById(elementID)
     ?.cloneNode(true);
-  const width = _svg?.getAttribute('width').replace('px', '');
-  const height = _svg?.getAttribute('height').replace('px', '');
+  const width = Number(_svg?.getAttribute('width').replace('px', ''));
+  const height = Number(_svg?.getAttribute('height').replace('px', ''));
   _svg
     .querySelectorAll('[data-no-export="true"]')
     .forEach((element) => element.remove());
@@ -295,4 +302,5 @@ export {
   copyHTMLToClipboard,
   exportAsMol,
   exportAsMatrix,
+  getBlob,
 };


### PR DESCRIPTION
@targos 
we use useImperativeHandle to customize the instance value that is exposed to parent components when using ref so it is possible to call the generate a Blob function, and then they can do whatever they need with this blob, to store it in the database or save as png or svg  ... etc in an external file server.

https://github.com/cheminfo/nmrium/issues/1569