### PR TITLE
refactor: export utility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "analysis-ui-components": "^0.17.3",
         "cheminfo-font": "^1.9.0",
         "cheminfo-types": "^1.4.0",
+        "clipboard-polyfill": "^4.0.0-rc1",
         "d3": "^7.6.1",
         "eventemitter3": "^4.0.7",
         "file-saver": "^2.0.5",
@@ -3567,6 +3568,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/clipboard-polyfill": {
+      "version": "4.0.0-rc1",
+      "resolved": "https://registry.npmjs.org/clipboard-polyfill/-/clipboard-polyfill-4.0.0-rc1.tgz",
+      "integrity": "sha512-Cel03Es9ZgP6pYA2JT9cZ2VgvOH2/EHgB7jji84FpINBJWqfMEwiI1Y3LstVL+E43cm3CnCrLL2vwb9DMbr28A==",
+      "deprecated": "Use the browser-native async clipboard API instead of this library: https://developer.mozilla.org/en-US/docs/Web/API/Clipboard"
     },
     "node_modules/clipboardy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "analysis-ui-components": "^0.17.3",
     "cheminfo-font": "^1.9.0",
     "cheminfo-types": "^1.4.0",
+    "clipboard-polyfill": "^4.0.0-rc1",
     "d3": "^7.6.1",
     "eventemitter3": "^4.0.7",
     "file-saver": "^2.0.5",

--- a/src/component/NMRium.tsx
+++ b/src/component/NMRium.tsx
@@ -67,7 +67,7 @@ import {
   SET_MOUSE_OVER_DISPLAYER,
 } from './reducer/types/Types';
 import ToolBar from './toolbar/ToolBar';
-import { BlobObject, getBlob } from './utility/Export';
+import { BlobObject, getBlob } from './utility/export';
 
 const viewerContainerStyle = css`
   border: 0.55px #e6e6e6 solid;

--- a/src/component/hooks/useExport.tsx
+++ b/src/component/hooks/useExport.tsx
@@ -11,7 +11,7 @@ import {
   exportAsJSON,
   exportAsPng,
   exportAsSVG,
-} from '../utility/Export';
+} from '../utility/export';
 
 export default function useExport() {
   const { rootRef } = useGlobal();

--- a/src/component/modal/ExportAsMatrixModal.tsx
+++ b/src/component/modal/ExportAsMatrixModal.tsx
@@ -8,7 +8,7 @@ import Label from '../elements/Label';
 import FormikForm from '../elements/formik/FormikForm';
 import FormikInput from '../elements/formik/FormikInput';
 import Events from '../utility/Events';
-import { exportAsMatrix } from '../utility/Export';
+import { exportAsMatrix } from '../utility/export';
 
 import { ModalStyles } from './ModalStyle';
 

--- a/src/component/panels/MoleculesPanel/MoleculePanelHeader.tsx
+++ b/src/component/panels/MoleculesPanel/MoleculePanelHeader.tsx
@@ -36,7 +36,7 @@ import {
   copyPNGToClipboard,
   copyTextToClipboard,
   exportAsSVG,
-} from '../../utility/Export';
+} from '../../utility/export';
 
 const toolbarStyle = css`
   display: flex;

--- a/src/component/panels/MultipleSpectraAnalysisPanel/MultipleSpectraAnalysisPanel.tsx
+++ b/src/component/panels/MultipleSpectraAnalysisPanel/MultipleSpectraAnalysisPanel.tsx
@@ -18,7 +18,7 @@ import { useModal } from '../../elements/popup/Modal';
 import AlignSpectraModal from '../../modal/AlignSpectraModal';
 import { RESET_SELECTED_TOOL } from '../../reducer/types/Types';
 import Events from '../../utility/Events';
-import { copyTextToClipboard } from '../../utility/Export';
+import { copyTextToClipboard } from '../../utility/export';
 import { tablePanelStyle } from '../extra/BasicPanelStyle';
 import DefaultPanelHeader from '../header/DefaultPanelHeader';
 import PreferencesHeader from '../header/PreferencesHeader';

--- a/src/component/panels/RangesPanel/RangesHeader.tsx
+++ b/src/component/panels/RangesPanel/RangesHeader.tsx
@@ -32,7 +32,7 @@ import {
   SHOW_MULTIPLICTY_TREES,
   SHOW_RANGES_INTEGRALS,
 } from '../../reducer/types/Types';
-import { copyHTMLToClipboard } from '../../utility/Export';
+import { copyHTMLToClipboard } from '../../utility/export';
 import { getNumberOfDecimals } from '../../utility/formatNumber';
 import DefaultPanelHeader from '../header/DefaultPanelHeader';
 

--- a/src/component/panels/RangesPanel/RangesPanel.tsx
+++ b/src/component/panels/RangesPanel/RangesPanel.tsx
@@ -13,7 +13,7 @@ import { usePanelPreferences } from '../../hooks/usePanelPreferences';
 import useSpectrum from '../../hooks/useSpectrum';
 import { rangeStateInit } from '../../reducer/Reducer';
 import { UNLINK_RANGE } from '../../reducer/types/Types';
-import { copyTextToClipboard } from '../../utility/Export';
+import { copyTextToClipboard } from '../../utility/export';
 import { WorkSpacePanelPreferences } from '../../workspaces/Workspace';
 import { tablePanelStyle } from '../extra/BasicPanelStyle';
 import NoTableData from '../extra/placeholder/NoTableData';

--- a/src/component/panels/SpectrumsPanel/SpectrumsTabs.tsx
+++ b/src/component/panels/SpectrumsPanel/SpectrumsTabs.tsx
@@ -17,8 +17,8 @@ import {
   CHANGE_ACTIVE_SPECTRUM,
   DELETE_SPECTRA,
 } from '../../reducer/types/Types';
-import { copyTextToClipboard } from '../../utility/Export';
 import groupByInfoKey from '../../utility/GroupByInfoKey';
+import { copyTextToClipboard } from '../../utility/export';
 
 import SpectrumListItem from './SpectrumListItem';
 import SpectrumSetting from './base/setting/SpectrumSetting';

--- a/src/demo/views/Exam.tsx
+++ b/src/demo/views/Exam.tsx
@@ -7,7 +7,7 @@ import { MF } from 'react-mf';
 import { StructureEditor } from 'react-ocl/full';
 
 import NMRium from '../../component/NMRium';
-import { copyTextToClipboard } from '../../component/utility/Export';
+import { copyTextToClipboard } from '../../component/utility/export';
 
 let answers = JSON.parse(localStorage.getItem('nmrium-exams') || '{}');
 


### PR DESCRIPTION
- use a new package "clipboard-polyfill" as a temporary solution until the Firefox team implement ClipboardItem. 
- remove the hack way we use to copy HTML to the clipboard for Firefox. 
- rename the file from "Export" to "export"