### PR TITLE
chore: fix react table virtual scroll

### DIFF
--- a/src/component/elements/ReactTable/ReactTable.tsx
+++ b/src/component/elements/ReactTable/ReactTable.tsx
@@ -309,7 +309,7 @@ function ReactTable(props: ReactTableProps) {
     });
 
   useLayoutEffect(() => {
-    if (containerRef.current) {
+    if (containerRef.current && height) {
       const header = containerRef.current.querySelectorAll('thead');
       visibleRowsCountRef.current = Math.ceil(
         (height - header[0].clientHeight) / approxItemHeight,


### PR DESCRIPTION
wait for the container height value before calculating the virtual scroll boundary
