### PR TITLE
fix: extend preference dataSelection to jcamp format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "ml-stat": "^1.3.3",
         "multiplet-analysis": "^2.0.0",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "^0.7.25",
+        "nmr-load-save": "0.7.25-pre.1677093992",
         "nmr-processing": "^9.3.6",
         "nmredata": "^0.9.2",
         "numeral": "^2.0.6",
@@ -8433,9 +8433,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.7.25",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.7.25.tgz",
-      "integrity": "sha512-l6tS9WyX6DEJ/7LPblfNFIXnQaOI2uV5IyJjD6K9+pB2RiOScXlfSHL8o3j+62PLEjtxPflTBNGzMGRaZHtaVg==",
+      "version": "0.7.25-pre.1677093992",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.7.25-pre.1677093992.tgz",
+      "integrity": "sha512-s86LiMwRlod0kP5pcHHqTT5oiEEwEasBdOVpgCzTSepE0P5ZQxfgghYVwEY76NlY1R/sAtTcFpEN/7r3y77p3Q==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@types/lodash.merge": "^4.6.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "ml-stat": "^1.3.3",
         "multiplet-analysis": "^2.0.0",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "0.7.25-pre.1677093992",
+        "nmr-load-save": "0.7.25-pre.1677101092",
         "nmr-processing": "^9.3.6",
         "nmredata": "^0.9.2",
         "numeral": "^2.0.6",
@@ -8433,9 +8433,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.7.25-pre.1677093992",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.7.25-pre.1677093992.tgz",
-      "integrity": "sha512-s86LiMwRlod0kP5pcHHqTT5oiEEwEasBdOVpgCzTSepE0P5ZQxfgghYVwEY76NlY1R/sAtTcFpEN/7r3y77p3Q==",
+      "version": "0.7.25-pre.1677101092",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.7.25-pre.1677101092.tgz",
+      "integrity": "sha512-uahryjG7XjMRL2H7W/5nvqa2xWql4wA1g4g9+LTpp514rMi3iyMb00Vbbja2wcraYR0uXgDkdyhA8wOP1HVFrw==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@types/lodash.merge": "^4.6.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "ml-stat": "^1.3.3",
         "multiplet-analysis": "^2.0.0",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "0.7.25-pre.1677101092",
+        "nmr-load-save": "^0.7.26",
         "nmr-processing": "^9.3.6",
         "nmredata": "^0.9.2",
         "numeral": "^2.0.6",
@@ -8433,9 +8433,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.7.25-pre.1677101092",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.7.25-pre.1677101092.tgz",
-      "integrity": "sha512-uahryjG7XjMRL2H7W/5nvqa2xWql4wA1g4g9+LTpp514rMi3iyMb00Vbbja2wcraYR0uXgDkdyhA8wOP1HVFrw==",
+      "version": "0.7.26",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.7.26.tgz",
+      "integrity": "sha512-a3mAu+dR8zkpBeZUAVM4rQrIc+GyDkpieDMLsL3T2KoQzZ9JDDk5w4WtdzRequvGYOFQ+4s8gzjKJuY9NDnlKw==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@types/lodash.merge": "^4.6.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "ml-stat": "^1.3.3",
         "multiplet-analysis": "^2.0.0",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "^0.7.26",
+        "nmr-load-save": "^0.7.27",
         "nmr-processing": "^9.3.6",
         "nmredata": "^0.9.2",
         "numeral": "^2.0.6",
@@ -8433,9 +8433,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.7.26",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.7.26.tgz",
-      "integrity": "sha512-a3mAu+dR8zkpBeZUAVM4rQrIc+GyDkpieDMLsL3T2KoQzZ9JDDk5w4WtdzRequvGYOFQ+4s8gzjKJuY9NDnlKw==",
+      "version": "0.7.27",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.7.27.tgz",
+      "integrity": "sha512-y8Pmp5m2Xqu31zydiykXcaiBjYqa4tBZ+zl11Kv9v3PTN08pQGXc2J63T1PLbZI6SefujfM5xVaNkthowv2/dQ==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@types/lodash.merge": "^4.6.7",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ml-stat": "^1.3.3",
     "multiplet-analysis": "^2.0.0",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "^0.7.26",
+    "nmr-load-save": "^0.7.27",
     "nmr-processing": "^9.3.6",
     "nmredata": "^0.9.2",
     "numeral": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ml-stat": "^1.3.3",
     "multiplet-analysis": "^2.0.0",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "0.7.25-pre.1677101092",
+    "nmr-load-save": "^0.7.26",
     "nmr-processing": "^9.3.6",
     "nmredata": "^0.9.2",
     "numeral": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ml-stat": "^1.3.3",
     "multiplet-analysis": "^2.0.0",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "0.7.25-pre.1677093992",
+    "nmr-load-save": "0.7.25-pre.1677101092",
     "nmr-processing": "^9.3.6",
     "nmredata": "^0.9.2",
     "numeral": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "ml-stat": "^1.3.3",
     "multiplet-analysis": "^2.0.0",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "^0.7.25",
+    "nmr-load-save": "0.7.25-pre.1677093992",
     "nmr-processing": "^9.3.6",
     "nmredata": "^0.9.2",
     "numeral": "^2.0.6",

--- a/public/data/aspirin/aspirin_bruker_files.json
+++ b/public/data/aspirin/aspirin_bruker_files.json
@@ -41,7 +41,7 @@
           "isRealSpectrumVisible": true,
           "isVisibleInDomain": true
         },
-        "selector": {
+        "sourceSelector": {
           "files": [
             "data/aspirin/aspirinFiles/1/acqu",
             "data/aspirin/aspirinFiles/1/acqus",

--- a/public/data/aspirin/bruker_aspirin_zip.json
+++ b/public/data/aspirin/bruker_aspirin_zip.json
@@ -19,7 +19,7 @@
           "isPeaksMarkersVisible": true,
           "isVisibleInDomain": true
         },
-        "selector": {
+        "sourceSelector": {
           "files": [
             "data/aspirin/aspirin-1h.zip/1/acqu",
             "data/aspirin/aspirin-1h.zip/1/acqus",

--- a/public/data/brukerFolders/brukerFolderWithoutExpno.json
+++ b/public/data/brukerFolders/brukerFolderWithoutExpno.json
@@ -66,7 +66,7 @@
           "values": [],
           "options": {}
         },
-        "selector": {
+        "sourceSelector": {
           "files": [
             "data/brukerFolders/brukerWithoutExpno/acqus",
             "data/brukerFolders/brukerWithoutExpno/fid",
@@ -87,7 +87,7 @@
         },
         "id": "4a545db9-7444-437c-89cf-a52c2fb18ae4",
         "filters": [],
-        "selector": {
+        "sourceSelector": {
           "files": [
             "data/brukerFolders/brukerWithoutExpno/pdata/1/1i",
             "data/brukerFolders/brukerWithoutExpno/pdata/1/1r",

--- a/public/data/cytisine/1H_Cytisin_linkJcamp.json
+++ b/public/data/cytisine/1H_Cytisin_linkJcamp.json
@@ -20,7 +20,7 @@
           "isPeaksMarkersVisible": true,
           "isVisibleInDomain": true
         },
-        "selector": { "jcamp": { "index": 0 } }
+        "sourceSelector": { "jcamp": { "index": 0 } }
       }
     ]
   }

--- a/public/data/cytisine/2d/jresolv.json
+++ b/public/data/cytisine/2d/jresolv.json
@@ -9,7 +9,7 @@
     },
     "spectra": [
       {
-        "selector": {
+        "sourceSelector": {
           "files": ["data/cytisine/2d/j-resolv.jdx"]
         }
       }

--- a/public/data/nmriumFromSource.json
+++ b/public/data/nmriumFromSource.json
@@ -22,7 +22,7 @@
         },
         "id": "cdb2c073-9739-4f96-87d1-3f9bb1bad475",
         "filters": [],
-        "selector": {
+        "sourceSelector": {
           "files": [
             "data/multiSpectra.zip/bruker/UV1010_M1-1003-1002_6268756_ErISKLIoeB/10/fid",
             "data/multiSpectra.zip/bruker/UV1010_M1-1003-1002_6268756_ErISKLIoeB/10/acqus",
@@ -54,7 +54,7 @@
         },
         "id": "b2c07397-396f-46c7-913f-9bb1bad475bb",
         "filters": [],
-        "selector": {
+        "sourceSelector": {
           "files": [
             "data/multiSpectra.zip/bruker/UV1010_M1-1003-1002_6268756_ErISKLIoeB/10/pdata/1/1r",
             "data/multiSpectra.zip/bruker/UV1010_M1-1003-1002_6268756_ErISKLIoeB/10/pdata/1/1i",
@@ -99,7 +99,7 @@
           "values": [],
           "options": {}
         },
-        "selector": {
+        "sourceSelector": {
           "jcamp": {
             "index": 0
           },
@@ -132,7 +132,7 @@
           "values": [],
           "options": {}
         },
-        "selector": {
+        "sourceSelector": {
           "jcamp": {
             "index": 1
           },
@@ -165,7 +165,7 @@
           "values": [],
           "options": {}
         },
-        "selector": {
+        "sourceSelector": {
           "jcamp": {
             "index": 0
           },

--- a/src/component/loader/DropZone.tsx
+++ b/src/component/loader/DropZone.tsx
@@ -73,10 +73,10 @@ function DropZone(props) {
           parseMetaFileResult = await parseMetaFile(metaFile);
         }
 
-        const { nmrLoaders: selector } = preferences.current;
+        const { nmrLoaders: sourceSelector } = preferences.current;
         const { nmriumState, containsNmrium } = await readDropFiles(
           fileCollection,
-          { selector },
+          { sourceSelector },
         );
 
         if ((nmriumState as any)?.settings) {

--- a/src/component/panels/databasePanel/DatabaseStructureSearchModal.tsx
+++ b/src/component/panels/databasePanel/DatabaseStructureSearchModal.tsx
@@ -27,7 +27,7 @@ export function DatabaseStructureSearchModal({
           initialIDCode={idCode}
           svgMenu
           fragment
-          onChange={(mplFile, molecule, idCode) => onChange(idCode)}
+          onChange={(molFile, molecule, idCode) => onChange(idCode)}
         />
       </div>
     </div>


### PR DESCRIPTION
the idea is to filter jcamp data without parse completely the jcamp file. The filtering will works by the LDR `DATA_TYPE` and `DATA_CLASS`

fid data will expect:
DATA_TYPE  includes `FID`

ft data will expect
DATA_TYPE  includes `SPECTRUM`
DATA_CLASS  not includes `PEAK `

it should close too;
- #2130 