### PR TITLE
feat: improve assignments

### DIFF
--- a/src/component/1d/multiplicityTree/MultiplicityTree.tsx
+++ b/src/component/1d/multiplicityTree/MultiplicityTree.tsx
@@ -32,6 +32,7 @@ const cssStyle = css`
   .signal-target {
     visibility: hidden;
   }
+
   &:hover {
     .signal-target {
       visibility: visible;

--- a/src/component/1d/ranges/LinkButton.tsx
+++ b/src/component/1d/ranges/LinkButton.tsx
@@ -19,7 +19,14 @@ export function LinkButton(props: LinkButtonProps) {
     ...otherProps
   } = props;
   return (
-    <foreignObject width="16px" height="16px" x={x} y={y} className={className}>
+    <foreignObject
+      width="16px"
+      height="16px"
+      x={x}
+      y={y}
+      className={className}
+      data-no-export="true"
+    >
       <Button
         theme={isActive ? 'danger' : 'success'}
         style={{ width: '16px', height: '16px', padding: 0 }}

--- a/src/component/1d/ranges/LinkButton.tsx
+++ b/src/component/1d/ranges/LinkButton.tsx
@@ -2,22 +2,29 @@ import { FaLink } from 'react-icons/fa';
 
 import Button, { ButtonProps } from '../../elements/Button';
 
-interface LinkButtonProps {
+export interface LinkButtonProps extends Omit<ButtonProps, 'children'> {
   isActive: boolean;
-  onLink: ButtonProps['onClick'];
   x?: number;
   y?: number;
   className?: string;
 }
 
 export function LinkButton(props: LinkButtonProps) {
-  const { isActive, onLink, x = 0, y = 0, className = 'target' } = props;
+  const {
+    isActive,
+    onClick,
+    x = 0,
+    y = 5,
+    className = 'target',
+    ...otherProps
+  } = props;
   return (
     <foreignObject width="16px" height="16px" x={x} y={y} className={className}>
       <Button
         theme={isActive ? 'danger' : 'success'}
         style={{ width: '16px', height: '16px', padding: 0 }}
-        onClick={onLink}
+        onClick={onClick}
+        {...otherProps}
       >
         <FaLink style={{ fontSize: 9, margin: 'auto' }} />
       </Button>

--- a/src/component/1d/ranges/LinkButton.tsx
+++ b/src/component/1d/ranges/LinkButton.tsx
@@ -1,0 +1,26 @@
+import { FaLink } from 'react-icons/fa';
+
+import Button, { ButtonProps } from '../../elements/Button';
+
+interface LinkButtonProps {
+  isActive: boolean;
+  onLink: ButtonProps['onClick'];
+  x?: number;
+  y?: number;
+  className?: string;
+}
+
+export function LinkButton(props: LinkButtonProps) {
+  const { isActive, onLink, x = 0, y = 0, className = 'target' } = props;
+  return (
+    <foreignObject width="16px" height="16px" x={x} y={y} className={className}>
+      <Button
+        theme={isActive ? 'danger' : 'success'}
+        style={{ width: '16px', height: '16px', padding: 0 }}
+        onClick={onLink}
+      >
+        <FaLink style={{ fontSize: 9, margin: 'auto' }} />
+      </Button>
+    </foreignObject>
+  );
+}

--- a/src/component/1d/ranges/Range.tsx
+++ b/src/component/1d/ranges/Range.tsx
@@ -24,6 +24,7 @@ const style = css`
   .target {
     visibility: hidden;
   }
+
   &:hover {
     .target {
       visibility: visible;

--- a/src/component/1d/ranges/Range.tsx
+++ b/src/component/1d/ranges/Range.tsx
@@ -19,7 +19,6 @@ import { IntegralIndicator } from '../integral/IntegralIndicator';
 import { MultiplicityTree } from '../multiplicityTree/MultiplicityTree';
 
 import { LinkButton } from './LinkButton';
-import { useCallback } from 'react';
 
 const style = css`
   .target {
@@ -86,19 +85,16 @@ function Range({
     highlightRange.hide();
   }
 
-  const unAssignHandler = useCallback(
-    (signalIndex: number) => {
-      dispatch({
-        type: UNLINK_RANGE,
-        payload: {
-          rangeData: range,
-          assignmentData,
-          signalIndex,
-        },
-      });
-    },
-    [assignmentData, dispatch, range],
-  );
+  function unAssignHandler(signalIndex: number) {
+    dispatch({
+      type: UNLINK_RANGE,
+      payload: {
+        rangeData: range,
+        assignmentData,
+        signalIndex,
+      },
+    });
+  }
   function assignHandler() {
     if (!isBlockedByEditing) {
       if (!diaIDs) {

--- a/src/component/1d/ranges/Ranges.tsx
+++ b/src/component/1d/ranges/Ranges.tsx
@@ -32,7 +32,7 @@ function RangesInner({
       {ranges?.values?.map((range) => (
         <Fragment key={range.id}>
           <Range
-            rangeData={range}
+            range={range}
             selectedTool={selectedTool}
             showMultiplicityTrees={showMultiplicityTrees}
             relativeFormat={relativeFormat}

--- a/src/component/elements/Button.tsx
+++ b/src/component/elements/Button.tsx
@@ -226,7 +226,7 @@ const toolTipStyle = (orientation: TooltipOrientation) => {
   ]);
 };
 
-interface ButtonProps
+export interface ButtonProps
   extends Partial<ButtonStyle>,
     Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'color' | 'style'> {
   onClick?: (event?: MouseEvent<HTMLButtonElement>) => void;
@@ -234,16 +234,24 @@ interface ButtonProps
   toolTip?: string;
   tooltipOrientation?: TooltipOrientation;
   wrapperClassName?: string;
+  theme?: ColorTheme;
 }
 
 function Button(props: ButtonProps) {
+  const { theme = 'light', ...buttonProps } = props;
+  const { base, shade, tint } = colorPalettes[theme];
+
   const {
     onClick,
     size = 'small',
-    color = { base: 'black', hover: 'white' },
-    backgroundColor = { base: 'white', hover: 'black', active: 'black' },
+    color = { base: shade, hover: 'white' },
+    backgroundColor = {
+      base,
+      hover: shade,
+      active: tint,
+    },
     borderColor = 'transparent',
-    fill,
+    fill = 'solid',
     borderRadius,
     style = {},
     wrapperStyle = {},
@@ -251,7 +259,7 @@ function Button(props: ButtonProps) {
     tooltipOrientation = 'vertical',
     wrapperClassName,
     ...restProps
-  } = props;
+  } = buttonProps;
 
   return (
     <div
@@ -293,34 +301,34 @@ function Button(props: ButtonProps) {
   );
 }
 
-function ThemeButton(props: { colorTheme: ColorTheme } & ButtonProps) {
-  const { colorTheme, ...buttonProps } = props;
-  const { base, shade, tint } = colorPalettes[colorTheme];
+// function ThemeButton(props: { colorTheme: ColorTheme } & ButtonProps) {
+//   const { colorTheme, ...buttonProps } = props;
+//   const { base, shade, tint } = colorPalettes[colorTheme];
 
-  const {
-    color = { base: shade, hover: 'white' },
-    backgroundColor = {
-      base,
-      hover: shade,
-      active: tint,
-    },
-    fill = 'solid',
-    ...restProps
-  } = buttonProps;
-  return <Button {...{ fill, ...restProps, backgroundColor, color }} />;
-}
+//   const {
+//     color = { base: shade, hover: 'white' },
+//     backgroundColor = {
+//       base,
+//       hover: shade,
+//       active: tint,
+//     },
+//     fill = 'solid',
+//     ...restProps
+//   } = buttonProps;
+//   return <Button {...{ fill, ...restProps, backgroundColor, color }} />;
+// }
 
 Button.Done = function ButtonDone(props: ButtonProps) {
-  return <ThemeButton {...props} colorTheme="success" />;
+  return <Button {...props} theme="success" />;
 };
 Button.Danger = function ButtonDanger(props: ButtonProps) {
-  return <ThemeButton {...props} colorTheme="danger" />;
+  return <Button {...props} theme="danger" />;
 };
 Button.Action = function ButtonAction(props: ButtonProps) {
-  return <ThemeButton {...props} colorTheme="medium" />;
+  return <Button {...props} theme="medium" />;
 };
 Button.Secondary = function ButtonAction(props: ButtonProps) {
-  return <ThemeButton {...props} colorTheme="secondary" />;
+  return <Button {...props} theme="secondary" />;
 };
 Button.Info = function ButtonInfo(props: Omit<ButtonProps, 'children'>) {
   return (

--- a/src/component/highlight/index.tsx
+++ b/src/component/highlight/index.tsx
@@ -9,8 +9,8 @@ import {
   CSSProperties,
 } from 'react';
 
+import { Range } from '../../data/types/data1d';
 import { ExclusionZone } from '../../data/types/data1d/ExclusionZone';
-import { RangeData } from '../1d/ranges/Range';
 
 export enum HighlightEventSource {
   PEAK = 'PEAK',
@@ -40,7 +40,7 @@ interface SourceData {
     id?: string;
     jcampURL?: string;
     baseURL?: string;
-    ranges?: RangeData[];
+    ranges?: Range[];
     colKey?: string;
   } | null;
 }


### PR DESCRIPTION
- [X]  #2246

To make it easy to assign range or signal directly from the multiplicity tree or from the range, right now we have little green buttons at the level of range on the top right corner of the range and at each signal multiplicity tree on the left side of the tree.

you can simply click on the button (its color will change from green to red to indicate you are in the middle of the assignment process for range or signal ) and then select the atom that you want to assign to.
