### PR TITLE
check symmetry first for manual range picking

### DIFF
--- a/src/component/modal/MultipletAnalysisModal.tsx
+++ b/src/component/modal/MultipletAnalysisModal.tsx
@@ -155,8 +155,13 @@ export default function MultipletAnalysisModal({
       try {
         const result = analyseMultiplet(analysesProps, {
           frequency: info.originFrequency,
+          minimalResolution: 0.3,
+          maxTestedJ: 17,
           takeBestPartMultiplet: true,
-          symmetrizeEachStep: true,
+          correctVerticalOffset: true,
+          symmetrizeEachStep: false,
+          decreasingJvalues: true,
+          makeShortCutForSpeed: true,
           debug: true,
         });
         setCalcFinished(true);

--- a/src/data/data1d/Spectrum1D/ranges/__tests__/detectSignal.test.ts
+++ b/src/data/data1d/Spectrum1D/ranges/__tests__/detectSignal.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+
+import detectSignal from '../detectSignal';
+import { rangesToXY } from 'nmr-processing';
+
+describe('lineBroadening', () => {
+  it('simple x, re, im to 1 Hz exp.', () => {
+    const from = 0.98;
+    const to = 1.02;
+    const frequency = 400;
+    const { x, y: re } = rangesToXY(
+      [
+        {
+          from,
+          to,
+          signals: [
+            {
+              delta: 1,
+              multiplicity: 't',
+              js: [{ coupling: 7.2, multiplicity: 't' }],
+            },
+          ],
+        },
+      ],
+      { from: from - 0.02, to: to + 0.02, nbPoints: 512, frequency },
+    );
+    const result = detectSignal(
+      { x: new Float64Array(x), re },
+      { from, to, frequency },
+    );
+    expect(result?.multiplicity).toBe('t');
+    expect(result?.delta).toBeCloseTo(1, 3);
+    expect(result?.js[0].coupling).toBeCloseTo(7.2, 2);
+  });
+});


### PR DESCRIPTION
the symmetry check will be manage by multiplet-analysis package and we will use signalJoinCouplings to merge couplings, e.g. the pattern `dd` with closer coupling values into `t` based in a `tolerance` option.