### PR TITLE
fix: do not use p element in NoData component

### DIFF
--- a/src/component/loader/NoData.tsx
+++ b/src/component/loader/NoData.tsx
@@ -53,11 +53,11 @@ function NoData({
       style={{ ...styles.container, ...style }}
       {...(canOpenLoader && { onClick: openLoader })}
     >
-      <p style={styles.text}>
+      <div style={styles.text}>
         {isToolEnabled('import')
           ? emptyText
           : 'Importation feature has been disabled'}
-      </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
The children are not necessarily a simple string and it's not allowed
to have for example div as the child of p.
