### PR TITLE
add missing multiplicity in the solvent databases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "multiplet-analysis": "^2.1.1",
         "nmr-correlation": "^2.3.3",
         "nmr-load-save": "^0.12.1",
-        "nmr-processing": "^9.6.1",
+        "nmr-processing": "9.6.2-pre.1686575602",
         "nmredata": "^0.9.2",
         "numeral": "^2.0.6",
         "openchemlib": "^8.3.0",
@@ -9325,10 +9325,46 @@
         "varian-converter": "^0.3.2"
       }
     },
-    "node_modules/nmr-processing": {
+    "node_modules/nmr-load-save/node_modules/nmr-processing": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/nmr-processing/-/nmr-processing-9.6.1.tgz",
       "integrity": "sha512-jKUhIxvHpW2q+8pkzf3SDmYWLdboWqZooDXEqZk75m5b/oFSvKSTbVm20K2oaC1Xs/EjfbqdtIM95ftj9K8wlg==",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.1",
+        "@types/lodash": "^4.14.195",
+        "binary-search": "^1.3.6",
+        "brukerconverter": "^6.1.2",
+        "cross-fetch": "^3.1.5",
+        "form-data": "^4.0.0",
+        "gyromagnetic-ratio": "^1.0.0",
+        "is-any-array": "^2.0.0",
+        "linear-sum-assignment": "^1.0.5",
+        "lodash": "^4.17.21",
+        "ml-airpls": "^1.0.1",
+        "ml-baseline-correction-regression": "^1.0.1",
+        "ml-direct": "^0.1.3",
+        "ml-gsd": "^12.1.2",
+        "ml-hclust": "^3.1.0",
+        "ml-levenberg-marquardt": "^4.1.0",
+        "ml-matrix": "^6.10.4",
+        "ml-matrix-convolution": "^1.0.0",
+        "ml-matrix-peaks-finder": "^1.0.0",
+        "ml-peak-shape-generator": "^4.1.2",
+        "ml-signal-processing": "^1.0.3",
+        "ml-simple-clustering": "^0.1.0",
+        "ml-sparse-matrix": "^2.1.0",
+        "ml-spectra-processing": "^12.4.0",
+        "ml-tree-set": "^0.1.1",
+        "nmr-correlation": "^2.3.3",
+        "nmredata": "^0.9.2",
+        "openchemlib-utils": "^2.4.0",
+        "spectrum-generator": "^8.0.7"
+      }
+    },
+    "node_modules/nmr-processing": {
+      "version": "9.6.2-pre.1686575602",
+      "resolved": "https://registry.npmjs.org/nmr-processing/-/nmr-processing-9.6.2-pre.1686575602.tgz",
+      "integrity": "sha512-2lvg530EzmLiOEmb0bkDCfWRJqLQD2X12d/kIvvh0wMczOHhrb2q0MM4Ev+LwOLrkjQHhAhxNoL+21i/Ttbs9w==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1",
         "@types/lodash": "^4.14.195",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "multiplet-analysis": "^2.1.1",
     "nmr-correlation": "^2.3.3",
     "nmr-load-save": "^0.12.1",
-    "nmr-processing": "^9.6.1",
+    "nmr-processing": "9.6.2-pre.1686575602",
     "nmredata": "^0.9.2",
     "numeral": "^2.0.6",
     "openchemlib": "^8.3.0",


### PR DESCRIPTION
solvent databases lacks of some multiplicities like m or Br t that exists in the .tsv source file.