### PR TITLE
chore: move some logs to debug level

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "ml-stat": "^1.3.3",
         "multiplet-analysis": "^2.1.1",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "^0.13.1",
+        "nmr-load-save": "^0.13.2",
         "nmr-processing": "^9.7.1",
         "nmredata": "^0.9.2",
         "numeral": "^2.0.6",
@@ -9286,9 +9286,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.13.1.tgz",
-      "integrity": "sha512-GwbH0LhXyiyOqpJgdXYqu1oDBLfgYOKdxYZzOoJXYusRc+xjI1pRjracwOJIYzQ68jV2JYl8lGrIG/SQb4wSOg==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.13.2.tgz",
+      "integrity": "sha512-qUS/7bXnl07C6sP5YK7VtiVae/vvHxuSe7v6q2karwYHQdusABpGZgcNDlLWiWHGBpqytKSKRu7llOdzHRJu6w==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.0",
         "@types/lodash.merge": "^4.6.7",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ml-stat": "^1.3.3",
     "multiplet-analysis": "^2.1.1",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "^0.13.1",
+    "nmr-load-save": "^0.13.2",
     "nmr-processing": "^9.7.1",
     "nmredata": "^0.9.2",
     "numeral": "^2.0.6",


### PR DESCRIPTION
somes logs are not useful e.g when any spectra is loaded, it is related with: 
- https://github.com/cheminfo/nmr-load-save/issues/225