### PR TITLE
refactor: data-test-id to data-testid

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -27,5 +27,10 @@ rules:
     - error
     - ignore:
         - 'css'
+  react/forbid-dom-props:
+    - error
+    - forbid:
+        - propName: data-test-id
+          message: Use data-testid instead (testing framework standard)
 parserOptions:
   sourceType: module

--- a/src/component/1d/ApodizationLine.tsx
+++ b/src/component/1d/ApodizationLine.tsx
@@ -93,7 +93,7 @@ function ApodizationLine() {
 
   return (
     <path
-      data-test-id="apodization-line"
+      data-testid="apodization-line"
       stroke="green"
       fill="none"
       strokeWidth="2"

--- a/src/component/1d/Line.tsx
+++ b/src/component/1d/Line.tsx
@@ -49,7 +49,7 @@ function Line({ data, id, display, index }: LineProps) {
   return (
     <path
       className="line"
-      data-test-id="spectrum-line"
+      data-testid="spectrum-line"
       key={id}
       stroke={stroke}
       fill="none"

--- a/src/component/1d/ranges/Range.tsx
+++ b/src/component/1d/ranges/Range.tsx
@@ -115,7 +115,7 @@ function Range({
 
   return (
     <g
-      data-test-id="range"
+      data-testid="range"
       style={{ outline: 'none' }}
       key={id}
       onMouseEnter={mouseEnterHandler}

--- a/src/component/2d/ft/Contours.tsx
+++ b/src/component/2d/ft/Contours.tsx
@@ -112,7 +112,7 @@ function ContoursPaths({
   return (
     <path
       fill="none"
-      data-test-id="spectrum-line"
+      data-testid="spectrum-line"
       stroke={color}
       strokeWidth="1"
       opacity={opacity}

--- a/src/component/elements/popup/Modal/ConfirmDialog.tsx
+++ b/src/component/elements/popup/Modal/ConfirmDialog.tsx
@@ -91,7 +91,7 @@ function ConfirmationDialog({
   );
 
   return (
-    <div style={style} css={styles} data-test-id={id}>
+    <div style={style} css={styles} data-testid={id}>
       {render ? (
         render({ message, className: 'message' })
       ) : (

--- a/src/component/main/InnerNMRiumContents.tsx
+++ b/src/component/main/InnerNMRiumContents.tsx
@@ -132,7 +132,7 @@ export function InnerNMRiumContents(props: InnerNMRiumContentsProps) {
                   <KeysListenerTracker mainDivRef={mainDivRef} />
                   <div
                     id="nmrium-viewer"
-                    data-test-id="viewer"
+                    data-testid="viewer"
                     ref={viewerRef}
                     style={{
                       width: '100%',

--- a/src/component/panels/SpectrumsPanel/base/ShowHideSpectrumButton.tsx
+++ b/src/component/panels/SpectrumsPanel/base/ShowHideSpectrumButton.tsx
@@ -64,7 +64,7 @@ function DisplayButtons1D(props: ShowHideSpectrumButtonProps) {
 
   return (
     <button
-      data-test-id="hide-show-spectrum-button"
+      data-testid="hide-show-spectrum-button"
       style={buttonStyle}
       type="button"
       onClick={(e) => {

--- a/src/demo/views/Test.tsx
+++ b/src/demo/views/Test.tsx
@@ -196,7 +196,7 @@ export default function Test(props) {
                   : {}
               }
             >
-              <span data-test-id="data-count">{dataCount}</span> - Data Change:
+              <span data-testid="data-count">{dataCount}</span> - Data Change:
             </h3>
             <Inspector data={dataCallBack.data} />
             <h3
@@ -206,7 +206,7 @@ export default function Test(props) {
                   : {}
               }
             >
-              <span data-test-id="view-count">{viewCount}</span> - View Change:
+              <span data-testid="view-count">{viewCount}</span> - View Change:
             </h3>
             <Inspector data={viewCallBack.data} />
             <h3
@@ -216,7 +216,7 @@ export default function Test(props) {
                   : {}
               }
             >
-              <span data-test-id="settings-count">{settingsCount}</span> -
+              <span data-testid="settings-count">{settingsCount}</span> -
               Settings Change:
             </h3>
             <Inspector data={settingsCallBack.data} />

--- a/test-e2e/NmriumPage.ts
+++ b/test-e2e/NmriumPage.ts
@@ -10,7 +10,7 @@ export default class NmriumPage {
 
   public constructor(page: Page) {
     this.page = page;
-    this.viewerLocator = page.locator('data-test-id=viewer');
+    this.viewerLocator = page.getByTestId('viewer');
   }
 
   public static async create(page: Page): Promise<NmriumPage> {
@@ -53,9 +53,7 @@ export default class NmriumPage {
     await this.page.mouse.move(x + width / 2, y + height / 2);
   }
   public async getNumberOfDistinctColors() {
-    const Lines = this.page.locator(
-      `data-test-id=spectrum-line >> _react=Line`,
-    );
+    const Lines = this.page.getByTestId('spectrum-line').locator('_react=Line');
     // get all lines from locator
     const lines = await Lines.all();
     // get all colors from lines
@@ -152,9 +150,11 @@ export default class NmriumPage {
     await this.page.locator('input[name="workspaceName"]').fill(name);
 
     // Save the user workspace.
-    await this.page.click(
-      'data-test-id=save-workspace-dialog >> button >> text=Save',
-    );
+    await this.page
+      .getByTestId('save-workspace-dialog')
+      .locator('button')
+      .locator('text=Save')
+      .click();
 
     await this.dismissAlert('Preferences saved');
   }

--- a/test-e2e/core/basic.test.ts
+++ b/test-e2e/core/basic.test.ts
@@ -22,9 +22,7 @@ test('should load and display the 1D and 2D spectrum', async ({ page }) => {
   //switch to 2d
   await nmrium.page.click('_react=Tab[tabid="1H,1H"]');
 
-  const spectrumLineLocator = nmrium.page.locator(
-    'data-test-id=spectrum-line >> nth=0',
-  );
+  const spectrumLineLocator = nmrium.page.getByTestId('spectrum-line').nth(0);
 
   await expect(spectrumLineLocator).toBeVisible();
 });
@@ -36,8 +34,8 @@ test('check callbacks count', async ({ page }) => {
   await nmrium.page.click('li >> text=Full cytisine');
   await expect(nmrium.page.locator('#nmrSVG')).toBeVisible();
 
-  const dataCount = nmrium.page.locator('[data-test-id="data-count"]');
-  const viewCount = nmrium.page.locator('[data-test-id="view-count"]');
+  const dataCount = nmrium.page.getByTestId('data-count');
+  const viewCount = nmrium.page.getByTestId('view-count');
 
   await expect(dataCount).toContainText(/[2-5]/);
   await expect(viewCount).toContainText(/[2-7]/);
@@ -56,9 +54,7 @@ test('check callbacks count', async ({ page }) => {
   await expect(dataCount).toContainText(/[2-5]/);
   await expect(viewCount).toContainText(/[3-7]/);
 
-  const spectrumLineLocator = nmrium.page.locator(
-    'data-test-id=spectrum-line >> nth=0',
-  );
+  const spectrumLineLocator = nmrium.page.getByTestId('spectrum-line').nth(0);
 
   await expect(spectrumLineLocator).toBeVisible();
 });

--- a/test-e2e/panels/filters.test.ts
+++ b/test-e2e/panels/filters.test.ts
@@ -19,9 +19,7 @@ async function apodizationFilter(
     await nmrium.clickTool('apodization');
   }
 
-  await expect(
-    nmrium.page.locator('data-test-id=apodization-line'),
-  ).toBeVisible();
+  await expect(nmrium.page.getByTestId('apodization-line')).toBeVisible();
 
   await nmrium.page.click('button >> text=Apply');
 
@@ -134,9 +132,7 @@ test('process 1d FID 13c spectrum', async ({ page }) => {
     ).toHaveCount(6);
   });
   await test.step('Check spectrum is displayed', async () => {
-    await expect(
-      nmrium.page.locator('data-test-id=spectrum-line'),
-    ).toBeVisible();
+    await expect(nmrium.page.getByTestId('spectrum-line')).toBeVisible();
   });
 });
 test('process 13c spectrum with shortcuts', async ({ page }) => {

--- a/test-e2e/panels/ranges.test.ts
+++ b/test-e2e/panels/ranges.test.ts
@@ -14,7 +14,7 @@ async function addRange(
     startX,
     endX,
   });
-  await expect(nmrium.page.locator(`data-test-id=range`)).toHaveCount(count);
+  await expect(nmrium.page.getByTestId(`range`)).toHaveCount(count);
 }
 
 async function shiftSignal(nmrium: NmriumPage) {
@@ -32,9 +32,11 @@ async function shiftSignal(nmrium: NmriumPage) {
 }
 
 async function resizeRange(nmrium: NmriumPage) {
-  const rightResizer = nmrium.page.locator(
-    'data-test-id=range >> nth=0 >> _react=SVGResizerHandle >> nth=1',
-  );
+  const rightResizer = nmrium.page
+    .getByTestId('range')
+    .nth(0)
+    .locator('_react=SVGResizerHandle')
+    .nth(1);
 
   const {
     x,
@@ -53,9 +55,11 @@ async function resizeRange(nmrium: NmriumPage) {
   });
   await nmrium.page.mouse.up();
 
-  const greenArea = nmrium.page.locator(
-    'data-test-id=range >> nth=0 >> rect >> nth=0',
-  );
+  const greenArea = nmrium.page
+    .getByTestId('range')
+    .nth(0)
+    .locator('rect')
+    .nth(0);
 
   const { width } = (await greenArea.boundingBox()) as BoundingBox;
 
@@ -67,7 +71,7 @@ async function deleteRange(nmrium: NmriumPage) {
   const rangeLocator = nmrium.page.locator('_react=Range >> nth=0 ');
   await rangeLocator.hover();
   await nmrium.page.keyboard.press('Delete');
-  await expect(nmrium.page.locator('data-test-id=range')).toHaveCount(1);
+  await expect(nmrium.page.getByTestId('range')).toHaveCount(1);
 }
 
 test('Should ranges Add/resize/delete', async ({ page }) => {
@@ -109,9 +113,9 @@ test('Automatic ranges detection should work', async ({ page }) => {
   //apply auto ranges detection
   await nmrium.page.click('text=Auto ranges picking');
 
-  expect(
-    await nmrium.page.locator('data-test-id=range').count(),
-  ).toBeGreaterThanOrEqual(10);
+  expect(await nmrium.page.getByTestId('range').count()).toBeGreaterThanOrEqual(
+    10,
+  );
   const ranges = nmrium.page.locator(
     '_react=RangesTable >> _react=RangesTableRow',
   );
@@ -303,7 +307,7 @@ test('Auto peak picking on all spectra', async ({ page }) => {
     await nmrium.page.click('_react=SpectrumsTabs >> _react=Tab[tabid="1H"]');
     //open ranges panel
     await nmrium.clickPanel('Ranges');
-    await expect(nmrium.page.locator('data-test-id=range')).toHaveCount(16);
+    await expect(nmrium.page.getByTestId('range')).toHaveCount(16);
     await expect(
       nmrium.page.locator('_react=RangesTablePanel >> _react=PanelHeader'),
     ).toContainText('[ 16 ]');
@@ -312,7 +316,7 @@ test('Auto peak picking on all spectra', async ({ page }) => {
   await test.step("Check 13C spectrum's ranges", async () => {
     // switch to 13C tab.
     await nmrium.page.click('_react=SpectrumsTabs >> _react=Tab[tabid="13C"]');
-    await expect(nmrium.page.locator('data-test-id=range')).toHaveCount(15);
+    await expect(nmrium.page.getByTestId('range')).toHaveCount(15);
     await expect(
       nmrium.page.locator('_react=RangesTablePanel >> _react=PanelHeader'),
     ).toContainText('[ 15 ]');

--- a/test-e2e/panels/spectra.test.ts
+++ b/test-e2e/panels/spectra.test.ts
@@ -6,10 +6,10 @@ test('Should 1d spectrum hide/show', async ({ page }) => {
   const nmrium = await NmriumPage.create(page);
   await nmrium.open1D();
 
-  const spectrumButtonLocator = nmrium.page.locator(
-    'data-test-id=hide-show-spectrum-button',
+  const spectrumButtonLocator = nmrium.page.getByTestId(
+    'hide-show-spectrum-button',
   );
-  const spectrumLineLocator = nmrium.page.locator('data-test-id=spectrum-line');
+  const spectrumLineLocator = nmrium.page.getByTestId('spectrum-line');
 
   // Click on hide/show spectrum button.
   await spectrumButtonLocator.click();
@@ -44,10 +44,9 @@ test('Should Zoom', async ({ page }) => {
 
   const cursorStartX = boundingBox.x + boundingBox.width / 2;
   const cursorStartY = boundingBox.y + boundingBox.height / 2;
-  const previousPath = (await nmrium.page.getAttribute(
-    'data-test-id=spectrum-line',
-    'd',
-  )) as string;
+  const previousPath = (await nmrium.page
+    .getByTestId('spectrum-line')
+    .getAttribute('d')) as string;
 
   await nmrium.page.mouse.move(cursorStartX, cursorStartY, { steps: 15 });
   await nmrium.page.mouse.down();
@@ -56,10 +55,9 @@ test('Should Zoom', async ({ page }) => {
   });
   await nmrium.page.mouse.up();
 
-  const path = (await nmrium.page.getAttribute(
-    'data-test-id=spectrum-line',
-    'd',
-  )) as string;
+  const path = (await nmrium.page
+    .getByTestId('spectrum-line')
+    .getAttribute('d')) as string;
 
   expect(path.length).toBeGreaterThan(1000);
   expect(path).not.toContain('NaN');
@@ -97,9 +95,7 @@ test('Should 2d deactivate spectrum', async ({ page }) => {
     '_react=SpectraTable >> _react=ReactTableRow >> nth=0',
   );
 
-  const spectrumLineLocator = nmrium.page.locator(
-    'data-test-id=spectrum-line >> nth=0',
-  );
+  const spectrumLineLocator = nmrium.page.getByTestId('spectrum-line').nth(0);
 
   // deactivate spectrum
   await spectrumButtonLocator.click();
@@ -132,9 +128,9 @@ test('2d spectrum', async ({ page }) => {
     ).toBeVisible();
     // Check spectrum initial color match with ColorIndicator
     await expect(
-      nmrium.page.locator(
-        'data-test-id=spectrum-line >> _react=Line[display.color="#7c2353"]',
-      ),
+      nmrium.page
+        .getByTestId('spectrum-line')
+        .locator('_react=Line[display.color="#7c2353"]'),
     ).toBeVisible();
 
     // Open Change color modal
@@ -151,9 +147,9 @@ test('2d spectrum', async ({ page }) => {
     ).toBeVisible();
     // Check that spectrum color changed
     await expect(
-      nmrium.page.locator(
-        'data-test-id=spectrum-line >> _react=Line[display.color="#ddb1c9ff"]',
-      ),
+      nmrium.page
+        .getByTestId('spectrum-line')
+        .locator('_react=Line[display.color="#ddb1c9ff"]'),
     ).toBeVisible();
 
     // Close color picker
@@ -177,9 +173,7 @@ test('2d spectrum', async ({ page }) => {
     await expect(
       nmrium.page.locator('_react=ContoursPaths[sign="negative"]'),
     ).toBeVisible();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      2,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(2);
   });
   await test.step('Change 1H,1H spectrum color', async () => {
     // Check ColorIndicator initial color
@@ -243,9 +237,7 @@ test('2d spectrum', async ({ page }) => {
     await expect(
       nmrium.page.locator('_react=ContoursPaths[sign="negative"]'),
     ).toBeVisible();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      1,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(1);
 
     // Hide negative spectrum
     await nmrium.page.click(
@@ -257,9 +249,7 @@ test('2d spectrum', async ({ page }) => {
     await expect(
       nmrium.page.locator('_react=ContoursPaths[sign="negative"]'),
     ).toBeHidden();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      0,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(0);
     // Show positive spectrum
     await nmrium.page.click(
       '_react=ShowHideSpectrumButton >> _react=FaEye >> nth=0',
@@ -270,9 +260,7 @@ test('2d spectrum', async ({ page }) => {
     await expect(
       nmrium.page.locator('_react=ContoursPaths[sign="negative"]'),
     ).toBeHidden();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      1,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(1);
 
     // Show negative spectrum
     await nmrium.page.click(
@@ -284,9 +272,7 @@ test('2d spectrum', async ({ page }) => {
     await expect(
       nmrium.page.locator('_react=ContoursPaths[sign="negative"]'),
     ).toBeVisible();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      2,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(2);
   });
   await test.step('Delete 1H tab', async () => {
     // Go to 1H tab
@@ -314,9 +300,7 @@ test('2d spectrum', async ({ page }) => {
     await expect(
       nmrium.page.locator('_react=ContoursPaths[sign="negative"]'),
     ).toBeVisible();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      2,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(2);
   });
   await test.step('Add projection', async () => {
     // Click add missing projection btn
@@ -338,9 +322,7 @@ test('2d spectrum', async ({ page }) => {
     await expect(
       nmrium.page.locator('_react=ContoursPaths[sign="negative"]'),
     ).toBeVisible();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      2,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(2);
   });
 });
 
@@ -352,41 +334,31 @@ test('show/hide spectrum', async ({ page }) => {
     await nmrium.page.click('li >> text=Coffee');
     // Wait the spectrum to load
     await expect(nmrium.page.locator('#nmrSVG')).toBeVisible();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      13,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(13);
   });
   await test.step('Check hide spectrums', async () => {
     // Hide positive spectrum
     await nmrium.page.click(
       '_react=ShowHideSpectrumButton >> _react=FaEye >> nth=0',
     );
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      12,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(12);
 
     // Hide negative spectrum
     await nmrium.page.click(
       '_react=ShowHideSpectrumButton >> _react=FaEye >> nth=1',
     );
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      11,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(11);
     // Show positive spectrum
     await nmrium.page.click(
       '_react=ShowHideSpectrumButton >> _react=FaEye >> nth=0',
     );
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      12,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(12);
 
     // Show negative spectrum
     await nmrium.page.click(
       '_react=ShowHideSpectrumButton >> _react=FaEye >> nth=1',
     );
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      13,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(13);
   });
 });
 
@@ -565,9 +537,7 @@ test('Multiple spectra analysis', async ({ page }) => {
     await nmrium.page.click('li >> text=Coffee');
     // Wait the spectrum to load
     await expect(nmrium.page.locator('#nmrSVG')).toBeVisible();
-    await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-      13,
-    );
+    await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(13);
   });
   await test.step('Check spectra names', async () => {
     for (let i = 0; i < 13; i++) {
@@ -622,7 +592,5 @@ test('Load JResolv', async ({ page }) => {
   await nmrium.page.click('li >> text=jResolv cytisine');
 
   await expect(nmrium.page.locator('#nmrSVG')).toBeVisible();
-  await expect(nmrium.page.locator('data-test-id=spectrum-line')).toHaveCount(
-    2,
-  );
+  await expect(nmrium.page.getByTestId('spectrum-line')).toHaveCount(2);
 });

--- a/test-e2e/panels/structures.test.ts
+++ b/test-e2e/panels/structures.test.ts
@@ -491,15 +491,13 @@ async function getCount(locator: Locator): Promise<number> {
 
 test('check callbacks count on changing structures', async ({ page }) => {
   const nmrium = await NmriumPage.create(page);
-  const dataCount = nmrium.page.locator('[data-test-id="data-count"]');
-  const viewCount = nmrium.page.locator('[data-test-id="view-count"]');
+  const dataCount = nmrium.page.getByTestId('data-count');
+  const viewCount = nmrium.page.getByTestId('view-count');
   await test.step('open test page', async () => {
     await nmrium.page.click('li >> text=Callback');
     await nmrium.page.click('li >> text=1H spectrum cytisine');
     // wait the spectrum to load
-    await expect(
-      nmrium.page.locator('data-test-id=spectrum-line'),
-    ).toBeVisible();
+    await expect(nmrium.page.getByTestId('spectrum-line')).toBeVisible();
 
     await expect(dataCount).toContainText(/[2-5]/);
     await expect(viewCount).toContainText(/[2-5]/);


### PR DESCRIPTION
this is the standard for testing with playwright.
use getByTestId("name") instead locator('[data-test-id="name"]')

Closes: https://github.com/cheminfo/nmrium/issues/2584