### PR TITLE
fix: read gyromagnetic ratio correctly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ml-stat": "^1.3.3",
         "multiplet-analysis": "^2.1.2",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "^0.23.3",
+        "nmr-load-save": "^0.23.4",
         "nmr-processing": "^11.6.0",
         "nmredata": "^0.9.7",
         "numeral": "^2.0.6",
@@ -7374,9 +7374,9 @@
       "dev": true
     },
     "node_modules/gyromagnetic-ratio": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gyromagnetic-ratio/-/gyromagnetic-ratio-1.0.0.tgz",
-      "integrity": "sha512-s55NtJPxoplsW/8OnM1C7tNWd2gEXXt+roF3NPNDKFb7YchBy9JXdxmzztf3d4JL1zCiQz5cn6HSC8M0osN78w=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/gyromagnetic-ratio/-/gyromagnetic-ratio-1.1.1.tgz",
+      "integrity": "sha512-M1y9bAhK11moqAPRZ5oUoDCEIQCogjKYXDMlkXJiSjkLFmOAp1qevrjThF+6KrtwkSpmT7Vgy8C/mgBlIdZPSg=="
     },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
@@ -8337,14 +8337,14 @@
       }
     },
     "node_modules/jcampconverter": {
-      "version": "9.4.1",
-      "resolved": "https://registry.npmjs.org/jcampconverter/-/jcampconverter-9.4.1.tgz",
-      "integrity": "sha512-P+0FRkDx4hYCZ0q5BWdoiQTa1kf2maw9A12iUMvnkrQ18f04rZ1WDUhPFEFaMquNujucqNQ9lbYUoR08PFmlXg==",
+      "version": "9.4.2",
+      "resolved": "https://registry.npmjs.org/jcampconverter/-/jcampconverter-9.4.2.tgz",
+      "integrity": "sha512-yTC4PgSMYeo+hHY/n9G+WgjGbjgwsdvEcu9FaJx55iRelHshulZ2HF3qPfwR4lH5vVpI0aQoplRYsE0MTUz18w==",
       "dependencies": {
         "cheminfo-types": "^1.7.2",
         "dynamic-typing": "^1.0.0",
         "ensure-string": "^1.2.0",
-        "gyromagnetic-ratio": "^1.0.0",
+        "gyromagnetic-ratio": "^1.1.1",
         "ml-array-median": "^1.1.6"
       }
     },
@@ -9539,9 +9539,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.23.3",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.23.3.tgz",
-      "integrity": "sha512-g8p0Ympb+UiE4PXQoCA2pR4q9wRCWEk/8bpKKLEUrugDZbUzq+f6B5ws3eG1P0caUkof832gqgQLH4pC5Q9S3A==",
+      "version": "0.23.4",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.23.4.tgz",
+      "integrity": "sha512-A7PFWXBEwlFjjrTcvNAK++Lafl/nca6GGWuLB0uQ8ni6qAsBQ4Xnr6Inv0ZKJfpR6bR17hJgX2EL+A5BPi8xwg==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1",
         "@types/lodash.merge": "^4.6.7",
@@ -9549,9 +9549,9 @@
         "cheminfo-types": "^1.7.2",
         "convert-to-jcamp": "^5.4.9",
         "filelist-utils": "^1.10.2",
-        "gyromagnetic-ratio": "^1.0.0",
+        "gyromagnetic-ratio": "^1.1.0",
         "is-any-array": "^2.0.1",
-        "jcampconverter": "^9.4.1",
+        "jcampconverter": "^9.4.2",
         "jeolconverter": "^1.0.2",
         "lodash.merge": "^4.6.2",
         "ml-spectra-processing": "^12.5.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ml-stat": "^1.3.3",
     "multiplet-analysis": "^2.1.2",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "^0.23.3",
+    "nmr-load-save": "^0.23.4",
     "nmr-processing": "^11.6.0",
     "nmredata": "^0.9.7",
     "numeral": "^2.0.6",


### PR DESCRIPTION
chore: update nmr-load-save to version 0.23.4