### PR TITLE
fix: jcamp tree filtering n wrong scale on F1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ml-stat": "^1.3.3",
         "multiplet-analysis": "^2.1.2",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "^0.23.4",
+        "nmr-load-save": "^0.23.5",
         "nmr-processing": "^11.6.0",
         "nmredata": "^0.9.7",
         "numeral": "^2.0.6",
@@ -8337,9 +8337,9 @@
       }
     },
     "node_modules/jcampconverter": {
-      "version": "9.4.2",
-      "resolved": "https://registry.npmjs.org/jcampconverter/-/jcampconverter-9.4.2.tgz",
-      "integrity": "sha512-yTC4PgSMYeo+hHY/n9G+WgjGbjgwsdvEcu9FaJx55iRelHshulZ2HF3qPfwR4lH5vVpI0aQoplRYsE0MTUz18w==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/jcampconverter/-/jcampconverter-9.5.0.tgz",
+      "integrity": "sha512-xsuZXcUd+YkF0Rlt0IZa1+4XbMYq/fR6+gewwDJd5M17y2+SbjrgESKZH73+GokzLC7H1KTS0/l5/7cQFFLgiA==",
       "dependencies": {
         "cheminfo-types": "^1.7.2",
         "dynamic-typing": "^1.0.0",
@@ -9539,9 +9539,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.23.4.tgz",
-      "integrity": "sha512-A7PFWXBEwlFjjrTcvNAK++Lafl/nca6GGWuLB0uQ8ni6qAsBQ4Xnr6Inv0ZKJfpR6bR17hJgX2EL+A5BPi8xwg==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.23.5.tgz",
+      "integrity": "sha512-dpBGXvQCaCnblvo87ILf4AkFfNg2BYtgVGZPoBqvS2O8uQbKwL5tUNep9peyVF336nvRrzzfkIih1bTpYu4BPQ==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1",
         "@types/lodash.merge": "^4.6.7",
@@ -9551,7 +9551,7 @@
         "filelist-utils": "^1.10.2",
         "gyromagnetic-ratio": "^1.1.0",
         "is-any-array": "^2.0.1",
-        "jcampconverter": "^9.4.2",
+        "jcampconverter": "^9.5.0",
         "jeolconverter": "^1.0.2",
         "lodash.merge": "^4.6.2",
         "ml-spectra-processing": "^12.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "ml-stat": "^1.3.3",
         "multiplet-analysis": "^2.1.2",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "^0.23.5",
+        "nmr-load-save": "^0.23.6",
         "nmr-processing": "^11.6.0",
         "nmredata": "^0.9.7",
         "numeral": "^2.0.6",
@@ -9539,9 +9539,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.23.5",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.23.5.tgz",
-      "integrity": "sha512-dpBGXvQCaCnblvo87ILf4AkFfNg2BYtgVGZPoBqvS2O8uQbKwL5tUNep9peyVF336nvRrzzfkIih1bTpYu4BPQ==",
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.23.6.tgz",
+      "integrity": "sha512-F+z7IdzDNM1mokybnhUq0nyQhxMif7oNqLloWBRS1HQjh44gdMw+EUuW75izEWPisKmU1qkgUbeRR/D7UQ8/9A==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1",
         "@types/lodash.merge": "^4.6.7",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ml-stat": "^1.3.3",
     "multiplet-analysis": "^2.1.2",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "^0.23.4",
+    "nmr-load-save": "^0.23.5",
     "nmr-processing": "^11.6.0",
     "nmredata": "^0.9.7",
     "numeral": "^2.0.6",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ml-stat": "^1.3.3",
     "multiplet-analysis": "^2.1.2",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "^0.23.5",
+    "nmr-load-save": "^0.23.6",
     "nmr-processing": "^11.6.0",
     "nmredata": "^0.9.7",
     "numeral": "^2.0.6",

--- a/test-e2e/panels/ranges.test.ts
+++ b/test-e2e/panels/ranges.test.ts
@@ -422,8 +422,8 @@ test('2D spectra reference change', async ({ page }) => {
       nmrium.page.locator('_react=ZonesPanel >> _react=PanelHeader'),
     ).toContainText('[ 15 ]');
 
-    const x = 2.9139017520509753;
-    const y = 35.65263186073236;
+    const x = 2.9139017520593895;
+    const y = 35.65263186072366;
     await expect(
       nmrium.page.locator(
         '_react=ZonesPanel >> _react=ZonesTableRow >> nth=0 >> td >> nth=1',


### PR DESCRIPTION
Also with version 0.23.6 of nmr-load-save, the molfile could be generated from `jcamp-cs` data, thanks to using the new feature `parseJcampCS`in jcampconverter