### PR TITLE
fix: add missing peaks when use multiplet-analysis

### DIFF
--- a/src/data/data1d/Spectrum1D/ranges/detectSignals.ts
+++ b/src/data/data1d/Spectrum1D/ranges/detectSignals.ts
@@ -1,12 +1,8 @@
 import { DataXY } from 'cheminfo-types';
 import { xGetFromToIndex } from 'ml-spectra-processing';
-import { analyseMultiplet } from 'multiplet-analysis';
-import {
-  NMRPeak1DWithShapeID,
-  signalJoinCouplings,
-  xyAutoPeaksPicking,
-  xyAutoRangesPicking,
-} from 'nmr-processing';
+import { xyAutoRangesPicking } from 'nmr-processing';
+
+import { detectSignalsByMultipletAnalysis } from './detectSignalsByMultipletAnalysis';
 
 const MAX_LENGTH = 4092;
 export default function detectSignals(
@@ -50,85 +46,3 @@ export default function detectSignals(
   }
 }
 
-function detectSignalsByMultipletAnalysis(data: DataXY, options: any) {
-  const { fromIndex, toIndex, frequency } = options;
-  const dataRoi = {
-    x: data.x.slice(fromIndex, toIndex),
-    y: data.y.slice(fromIndex, toIndex),
-  };
-
-  const result = analyseMultiplet(dataRoi, {
-    frequency,
-    minimalResolution: 0.1,
-    maxTestedJ: 17,
-    checkSymmetryFirst: true,
-    takeBestPartMultiplet: true,
-    correctVerticalOffset: true,
-    symmetrizeEachStep: false,
-    decreasingJvalues: true,
-    makeShortCutForSpeed: true,
-  });
-
-  if (result && result.chemShift === undefined) return [];
-
-  const { delta, js } = joinCouplings(result);
-
-  let cs = 0;
-  let area = 0;
-  for (let i = 0; i < dataRoi.x.length; i++) {
-    cs += dataRoi.x[i] * dataRoi.y[i];
-    area += dataRoi.y[i];
-  }
-  cs /= area;
-
-  const peaks = xyAutoPeaksPicking(dataRoi, { frequency });
-
-  const multiplicity = getMultiplicity(js, { cs, delta, peaks });
-
-  return [
-    {
-      multiplicity,
-      kind: 'signal',
-      delta: cs,
-      js,
-      peaks,
-      diaIDs: [],
-    },
-  ];
-}
-
-function getMultiplicity(
-  js,
-  options: { cs: number; delta: number; peaks: NMRPeak1DWithShapeID[] },
-) {
-  const { cs, delta, peaks } = options;
-
-  if (js?.length > 0) {
-    return js.map((j) => j.multiplicity).join('');
-  }
-  //check if the massive center is closer to the shift from multiplet-analysis,
-  //if true, is it possibly a singlet.
-  return peaks.length === 1 && Math.abs(cs - delta) / cs < 1e-3 ? 's' : 'm';
-}
-
-function joinCouplings(result: any) {
-  const { chemShift: delta, js } = result;
-  let jCouplings = js;
-  if (js.length > 1) {
-    try {
-      jCouplings = signalJoinCouplings(
-        {
-          delta,
-          js,
-        },
-        { tolerance: 0.6, ignoreDiaIDs: true },
-      ).js;
-    } catch (error) {
-      reportError(error);
-    }
-  }
-  return {
-    delta,
-    js: jCouplings,
-  };
-}

--- a/src/data/data1d/Spectrum1D/ranges/detectSignals.ts
+++ b/src/data/data1d/Spectrum1D/ranges/detectSignals.ts
@@ -45,4 +45,3 @@ export default function detectSignals(
     });
   }
 }
-

--- a/src/data/data1d/Spectrum1D/ranges/detectSignals.ts
+++ b/src/data/data1d/Spectrum1D/ranges/detectSignals.ts
@@ -81,7 +81,9 @@ function detectSignalsByMultipletAnalysis(data: DataXY, options: any) {
   }
   cs /= area;
 
-  const multiplicity = getMultiplicity(js, { cs, data, delta, frequency });
+  const peaks = xyAutoPeaksPicking(dataRoi, { frequency });
+
+  const multiplicity = getMultiplicity(js, { cs, delta, peaks });
 
   return [
     {
@@ -89,6 +91,7 @@ function detectSignalsByMultipletAnalysis(data: DataXY, options: any) {
       kind: 'signal',
       delta: cs,
       js,
+      peaks,
       diaIDs: [],
     },
   ];
@@ -96,26 +99,16 @@ function detectSignalsByMultipletAnalysis(data: DataXY, options: any) {
 
 function getMultiplicity(
   js,
-  options: { cs: number; delta: number; frequency: number; data: DataXY },
+  options: { cs: number; delta: number; peaks: NMRPeak1DWithShapeID[] },
 ) {
-  const { cs, delta, frequency, data } = options;
+  const { cs, delta, peaks } = options;
 
   if (js?.length > 0) {
     return js.map((j) => j.multiplicity).join('');
   }
   //check if the massive center is closer to the shift from multiplet-analysis,
   //if true, is it possibly a singlet.
-  if (Math.abs(cs - delta) / cs < 1e-3) {
-    let peaks: NMRPeak1DWithShapeID[] = [];
-
-    if (js?.length === 0) {
-      peaks = xyAutoPeaksPicking(data, { frequency });
-    }
-
-    if (peaks.length === 1) return 's';
-  }
-
-  return 'm';
+  return peaks.length === 1 && Math.abs(cs - delta) / cs < 1e-3 ? 's' : 'm';
 }
 
 function joinCouplings(result: any) {

--- a/src/data/data1d/Spectrum1D/ranges/detectSignalsByMultipletAnalysis.ts
+++ b/src/data/data1d/Spectrum1D/ranges/detectSignalsByMultipletAnalysis.ts
@@ -1,0 +1,90 @@
+import { DataXY } from 'cheminfo-types';
+import { analyseMultiplet } from 'multiplet-analysis';
+import {
+  NMRPeak1DWithShapeID,
+  signalJoinCouplings,
+  xyAutoPeaksPicking,
+} from 'nmr-processing';
+
+export function detectSignalsByMultipletAnalysis(data: DataXY, options: any) {
+  const { fromIndex, toIndex, frequency } = options;
+  const dataRoi = {
+    x: data.x.slice(fromIndex, toIndex),
+    y: data.y.slice(fromIndex, toIndex),
+  };
+
+  const result = analyseMultiplet(dataRoi, {
+    frequency,
+    minimalResolution: 0.1,
+    maxTestedJ: 17,
+    checkSymmetryFirst: true,
+    takeBestPartMultiplet: true,
+    correctVerticalOffset: true,
+    symmetrizeEachStep: false,
+    decreasingJvalues: true,
+    makeShortCutForSpeed: true,
+  });
+
+  if (result && result.chemShift === undefined) return [];
+
+  const { delta, js } = joinCouplings(result);
+
+  let cs = 0;
+  let area = 0;
+  for (let i = 0; i < dataRoi.x.length; i++) {
+    cs += dataRoi.x[i] * dataRoi.y[i];
+    area += dataRoi.y[i];
+  }
+  cs /= area;
+
+  const peaks = xyAutoPeaksPicking(dataRoi, { frequency });
+
+  const multiplicity = getMultiplicity(js, { cs, delta, peaks });
+
+  return [
+    {
+      multiplicity,
+      kind: 'signal',
+      delta: cs,
+      js,
+      peaks,
+      diaIDs: [],
+    },
+  ];
+}
+
+function getMultiplicity(
+  js,
+  options: { cs: number; delta: number; peaks: NMRPeak1DWithShapeID[] },
+) {
+  const { cs, delta, peaks } = options;
+
+  if (js?.length > 0) {
+    return js.map((j) => j.multiplicity).join('');
+  }
+  //check if the massive center is closer to the shift from multiplet-analysis,
+  //if true, is it possibly a singlet.
+  return peaks.length === 1 && Math.abs(cs - delta) / cs < 1e-3 ? 's' : 'm';
+}
+
+function joinCouplings(result: any) {
+  const { chemShift: delta, js } = result;
+  let jCouplings = js;
+  if (js.length > 1) {
+    try {
+      jCouplings = signalJoinCouplings(
+        {
+          delta,
+          js,
+        },
+        { tolerance: 0.6, ignoreDiaIDs: true },
+      ).js;
+    } catch (error) {
+      reportError(error);
+    }
+  }
+  return {
+    delta,
+    js: jCouplings,
+  };
+}


### PR DESCRIPTION
when data length is less than 4092 multiplet-analysis package is used

multiplet-analysis does not returns peaks, so an automatic peak picking is done on the ROI