### PR TITLE
fix: xy data with discontinuous x

### DIFF
--- a/src/component/hooks/useXYReduce.ts
+++ b/src/component/hooks/useXYReduce.ts
@@ -23,7 +23,7 @@ export default function useXYReduce(
         domainAxis === XYReducerDomainAxis.XAxis ? xDomain : yDomain;
       return xyReduce(
         { x, y },
-        { from, to, nbPoints: width * 4, optimize: true, zones: getZones(x)},
+        { from, to, nbPoints: width * 4, optimize: true, zones: getZones(x) },
       );
     },
     [domainAxis, width, xDomain, yDomain],
@@ -34,18 +34,18 @@ function getZones(x: Float64Array): FromTo[] {
   const zones: FromTo[] = [];
   let from = x[0];
   const deltaX = x[1] - x[0];
-  const deltaTol = deltaX * 0.005; // Accept deltas having this discrepancy as equal
+  const deltaTol = deltaX * 0.005;
   let i = 1;
-  for(; i < x.length; i++) {
-    if(Math.abs(x[i + 1] - x[i] - deltaX) > deltaTol) {
-      zones.push({from, to: x[i]})
+  for (; i < x.length; i++) {
+    if (Math.abs(x[i + 1] - x[i] - deltaX) > deltaTol) {
+      zones.push({ from, to: x[i] })
       from = x[i + 1];
       i++;
-    } 
+    }
   }
-  zones.push({from, to: x[i - 1]});
+  zones.push({ from, to: x[i - 1] });
 
-  if(zones.length >= x.length/10) {
+  if (zones.length >= x.length / 10) {
     // There are too many zones compared with the original x
     return [];
   }

--- a/src/component/hooks/useXYReduce.ts
+++ b/src/component/hooks/useXYReduce.ts
@@ -1,8 +1,9 @@
-import { DataXY, FromTo } from 'cheminfo-types';
+import { DataXY } from 'cheminfo-types';
 import { xyReduce } from 'ml-spectra-processing';
 import { useCallback } from 'react';
 
 import { useChartData } from '../context/ChartContext';
+import getFromToFromX from '../utility/getFromToFromX';
 
 export enum XYReducerDomainAxis {
   XAxis = 'XAxis',
@@ -23,31 +24,15 @@ export default function useXYReduce(
         domainAxis === XYReducerDomainAxis.XAxis ? xDomain : yDomain;
       return xyReduce(
         { x, y },
-        { from, to, nbPoints: width * 4, optimize: true, zones: getZones(x) },
+        {
+          from,
+          to,
+          nbPoints: width * 4,
+          optimize: true,
+          zones: getFromToFromX(x),
+        },
       );
     },
     [domainAxis, width, xDomain, yDomain],
   );
-}
-
-function getZones(x: Float64Array): FromTo[] {
-  const zones: FromTo[] = [];
-  let from = x[0];
-  const deltaX = x[1] - x[0];
-  const deltaTol = deltaX * 0.005;
-  let i = 1;
-  for (; i < x.length; i++) {
-    if (Math.abs(x[i + 1] - x[i] - deltaX) > deltaTol) {
-      zones.push({ from, to: x[i] });
-      from = x[i + 1];
-      i++;
-    }
-  }
-  zones.push({ from, to: x[i - 1] });
-
-  if (zones.length >= x.length / 10) {
-    return [];
-  }
-
-  return zones;
 }

--- a/src/component/hooks/useXYReduce.ts
+++ b/src/component/hooks/useXYReduce.ts
@@ -38,7 +38,7 @@ function getZones(x: Float64Array): FromTo[] {
   let i = 1;
   for (; i < x.length; i++) {
     if (Math.abs(x[i + 1] - x[i] - deltaX) > deltaTol) {
-      zones.push({ from, to: x[i] })
+      zones.push({ from, to: x[i] });
       from = x[i + 1];
       i++;
     }
@@ -46,7 +46,6 @@ function getZones(x: Float64Array): FromTo[] {
   zones.push({ from, to: x[i - 1] });
 
   if (zones.length >= x.length / 10) {
-    // There are too many zones compared with the original x
     return [];
   }
 

--- a/src/component/hooks/useXYReduce.ts
+++ b/src/component/hooks/useXYReduce.ts
@@ -1,4 +1,4 @@
-import { DataXY } from 'cheminfo-types';
+import { DataXY, FromTo } from 'cheminfo-types';
 import { xyReduce } from 'ml-spectra-processing';
 import { useCallback } from 'react';
 
@@ -23,9 +23,32 @@ export default function useXYReduce(
         domainAxis === XYReducerDomainAxis.XAxis ? xDomain : yDomain;
       return xyReduce(
         { x, y },
-        { from, to, nbPoints: width * 4, optimize: true },
+        { from, to, nbPoints: width * 4, optimize: true, zones: getZones(x)},
       );
     },
     [domainAxis, width, xDomain, yDomain],
   );
+}
+
+function getZones(x: Float64Array): FromTo[] {
+  const zones: FromTo[] = [];
+  let from = x[0];
+  const deltaX = x[1] - x[0];
+  const deltaTol = deltaX * 0.005; // Accept deltas having this discrepancy as equal
+  let i = 1;
+  for(; i < x.length; i++) {
+    if(Math.abs(x[i + 1] - x[i] - deltaX) > deltaTol) {
+      zones.push({from, to: x[i]})
+      from = x[i + 1];
+      i++;
+    } 
+  }
+  zones.push({from, to: x[i - 1]});
+
+  if(zones.length >= x.length/10) {
+    // There are too many zones compared with the original x
+    return [];
+  }
+
+  return zones;
 }

--- a/src/component/utility/__tests__/getFromToFromX.test.ts
+++ b/src/component/utility/__tests__/getFromToFromX.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { FromTo } from 'cheminfo-types';
+
+import getFromToFromX from '../getFromToFromX';
+
+describe('getFromToFromX', () => {
+  it('single zone', () => {
+    const x = new Float64Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const zones = getFromToFromX(x);
+    expect(zones).toStrictEqual([{ from: 1, to: 10 }] as FromTo[]);
+  });
+  it('two zones', () => {
+    const x = new Float64Array([1, 2, 3, 4, 6, 7, 8, 9, 10]);
+    const zones = getFromToFromX(x);
+    expect(zones).toStrictEqual([
+      { from: 1, to: 4 },
+      { from: 6, to: 10 },
+    ] as FromTo[]);
+  });
+  it('three zones, single right', () => {
+    const x = new Float64Array([
+      1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 19,
+    ]);
+    const zones = getFromToFromX(x);
+    expect(zones).toStrictEqual([
+      { from: 1, to: 4 },
+      { from: 6, to: 15 },
+      { from: 19, to: 19 },
+    ] as FromTo[]);
+  });
+  it('three zones, single middle', () => {
+    const x = new Float64Array([1, 2, 3, 5, 7, 8, 9, 10]);
+    const zones = getFromToFromX(x);
+    expect(zones).toStrictEqual([
+      { from: 1, to: 3 },
+      { from: 5, to: 5 },
+      { from: 7, to: 10 },
+    ] as FromTo[]);
+  });
+  it('non uniform x', () => {
+    const x = new Float64Array([1, 2, 4, 6, 8, 11, 14, 16, 19, 22, 25, 27, 31]);
+    const zones = getFromToFromX(x);
+    expect(zones).toStrictEqual([{ from: 1, to: 31 }] as FromTo[]);
+  });
+});

--- a/src/component/utility/getFromToFromX.ts
+++ b/src/component/utility/getFromToFromX.ts
@@ -1,0 +1,24 @@
+import { FromTo } from 'cheminfo-types';
+
+const MAX_ZONES = 10;
+//0,1,2,3,5,7,8,9,10
+export default function getFromToFromX(x: Float64Array): FromTo[] {
+  const zones: FromTo[] = [];
+  let from = x[0];
+  const deltaX = x[1] - x[0];
+  const deltaTol = deltaX * 0.005;
+  let i = 1;
+  const lastIndex = x.length - 1;
+  for (; i < x.length; i++) {
+    if (Math.abs(x[i + 1] - x[i] - deltaX) > deltaTol) {
+      zones.push({ from, to: x[i] });
+      from = x[i + 1];
+    }
+    if (zones.length === MAX_ZONES) {
+      return [{ from: x[0], to: x[lastIndex] }];
+    }
+  }
+
+  zones.push({ from, to: x[i - 1] });
+  return zones;
+}


### PR DESCRIPTION
Solve the issue by getting the zones at before calling `xyReduce`.

<img width="869" alt="Screenshot 2024-01-12 at 6 14 21 pm" src="https://github.com/cheminfo/nmrium/assets/3810292/72dbb248-a300-49fe-844d-ce29053e1d17">


Related to #2820