### PR TITLE
fix: copy image to clipboard in Firefox

### DIFF
--- a/src/component/hooks/useExport.tsx
+++ b/src/component/hooks/useExport.tsx
@@ -25,8 +25,8 @@ export default function useExport() {
       const hideLoading = await alert.showLoading(
         'Exporting as NMRium process in progress',
       );
-      setTimeout(() => {
-        copyPNGToClipboard(rootRef, 'nmrSVG');
+      setTimeout(async () => {
+        await copyPNGToClipboard(rootRef, 'nmrSVG');
         hideLoading();
         alert.success('Image copied to clipboard');
       }, 0);

--- a/src/component/panels/MoleculesPanel/MoleculePanelHeader.tsx
+++ b/src/component/panels/MoleculesPanel/MoleculePanelHeader.tsx
@@ -110,9 +110,9 @@ export default function MoleculePanelHeader({
     exportAsSVG(rootRef, `molSVG${currentIndex} `, 'molFile');
   }, [rootRef, currentIndex]);
 
-  const saveAsPNGHandler = useCallback(() => {
+  const saveAsPNGHandler = useCallback(async () => {
     if (!rootRef) return;
-    copyPNGToClipboard(rootRef, `molSVG${currentIndex} `);
+    await copyPNGToClipboard(rootRef, `molSVG${currentIndex} `);
     alert.success('MOL copied as PNG to clipboard');
   }, [rootRef, alert, currentIndex]);
 
@@ -149,7 +149,7 @@ export default function MoleculePanelHeader({
             break;
           }
           case 'png':
-            saveAsPNGHandler();
+            void saveAsPNGHandler();
             break;
           case 'svg':
             saveAsSVGHandler();

--- a/src/component/panels/multipleAnalysisPanel/AnalysisChart.tsx
+++ b/src/component/panels/multipleAnalysisPanel/AnalysisChart.tsx
@@ -124,7 +124,7 @@ export default function AnalysisChart(props: PlotChartPros) {
 
   function handleCopy() {
     if (chartParentRef.current) {
-      copyPNGToClipboard(
+      void copyPNGToClipboard(
         chartParentRef.current,
         svgId,
         css({ text: { fill: 'black' } }),


### PR DESCRIPTION
- #2713

we still have an issue with Safari 
```
NotAllowedError: The request is not allowed by the user agent or the platform in the current context, possibly because the user denied permission.
```

for Firefox 

To use setImageData, an extension must be added to Firefox, which is an extra step that I think all users will not do. Therefore, for now, I will maintain the current workaround solution

