### PR TITLE
fix: disable auto-translate of the NMRium component

### DIFF
--- a/src/component/main/InnerNMRium.tsx
+++ b/src/component/main/InnerNMRium.tsx
@@ -85,7 +85,11 @@ export function InnerNMRium({
   );
 
   return (
-    <div ref={mainDivRef} style={{ height: '100%', position: 'relative' }}>
+    <div
+      ref={mainDivRef}
+      style={{ height: '100%', position: 'relative' }}
+      translate="no"
+    >
       <GlobalProvider
         value={{
           rootRef: rootRef.current,


### PR DESCRIPTION
This leads to random crashes because browser translation manipulates the
DOM in a way that React can be confused.
