### PR TITLE
fix: prevent the refresh of the scale in baseline correction

### DIFF
--- a/src/component/reducer/actions/FiltersActions.ts
+++ b/src/component/reducer/actions/FiltersActions.ts
@@ -385,16 +385,18 @@ function disableLivePreview(draft: Draft<State>, id: string) {
     const index = activeSpectrum.index;
     const { data } = draft.tempData[index] as Spectrum1D;
     draft.data[index].data = data;
-    setDomain(draft);
 
     // reset default options
     switch (id) {
-      case apodization.name: {
+      case baselineCorrection.id: {
         draft.toolOptions.data.apodizationOptions = defaultApodizationOptions;
         break;
       }
       default: {
-        return null;
+        if (baselineCorrection.name !== id) {
+          setDomain(draft);
+        }
+        break;
       }
     }
   }


### PR DESCRIPTION
close #2872