### PR TITLE
chore: disable coverage reports for tests

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -14,6 +14,7 @@ jobs:
       lint-check-types: true
       node-version: 20.x
       node-version-matrix: '[18, 20]'
+      upload-coverage: false
   stylelint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
The codecov comments are not very relevant in this project as most files are tested through Playwright instead of unit tests.
