### PR TITLE
fix: set the size correctly for real part in slicing function

### DIFF
--- a/src/data/data2d/Spectrum2D/getSlice.ts
+++ b/src/data/data2d/Spectrum2D/getSlice.ts
@@ -104,7 +104,7 @@ export function getSlice(
 function initiateData(from: number, to: number, size: number): NmrData1D {
   return {
     x: xSequentialFillFromTo({ from, to, size }),
-    re: new Float64Array(length),
+    re: new Float64Array(size),
   };
 }
 

--- a/test-e2e/tools/slicing.test.ts
+++ b/test-e2e/tools/slicing.test.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+import NmriumPage from '../NmriumPage';
+
+test('Slicing too should show 1d (horizontal and vertical) traces', async ({
+  page,
+}) => {
+  const nmrium = await NmriumPage.create(page);
+  await nmrium.open2D();
+
+  await nmrium.clickTool('slicing');
+
+  await nmrium.viewer.moveMouse({ x: 200, y: 200 });
+
+  const horizontalPath = (await nmrium.page.getAttribute(
+    `_react=HorizontalSliceChart >> path >> nth=0`,
+    'd',
+  )) as string;
+  expect(horizontalPath.length).toBeGreaterThan(1000);
+  expect(horizontalPath).not.toContain('NaN');
+
+  const verticalPath = (await nmrium.page.getAttribute(
+    `_react=VerticalSliceChart >> path >> nth=0`,
+    'd',
+  )) as string;
+  expect(verticalPath.length).toBeGreaterThan(1000);
+  expect(verticalPath).not.toContain('NaN');
+});


### PR DESCRIPTION
We have encountered a major bug that causes failures in the slicing tool and 2D phase correction tool. This issue was introduced by the PR 
- https://github.com/cheminfo/nmrium/pull/2949