### PR TITLE
style: set tab list item gap to 0

### DIFF
--- a/src/component/modal/setting/GeneralSettings.tsx
+++ b/src/component/modal/setting/GeneralSettings.tsx
@@ -238,6 +238,10 @@ function InnerGeneralSettingsModal(props: InnerGeneralSettingsModalProps) {
               css={css`
                 height: 100%;
 
+                div[role='tablist'] {
+                  gap: 0;
+                }
+
                 div[role='tabpanel'] {
                   width: 100%;
                   padding: 0.8rem;
@@ -245,7 +249,6 @@ function InnerGeneralSettingsModal(props: InnerGeneralSettingsModalProps) {
                   max-height: 100%;
                 }
               `}
-              fill
             >
               <Tab title="General" id="general" panel={<GeneralTabContent />} />
 


### PR DESCRIPTION
In Blueprint.js version 5.10.4, the tab component has a fixed 20px gap between the tab list items