### PR TITLE
fix: do not allow deletion of digital filter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "ml-tree-similarity": "^2.2.0",
         "multiplet-analysis": "^2.1.2",
         "nmr-correlation": "^2.3.3",
-        "nmr-load-save": "^0.35.0",
+        "nmr-load-save": "^0.35.1",
         "nmr-processing": "^12.8.0",
         "nmredata": "^0.9.11",
         "numeral": "^2.0.6",
@@ -9551,9 +9551,9 @@
       }
     },
     "node_modules/nmr-load-save": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.35.0.tgz",
-      "integrity": "sha512-uur725neK10hdrbyVJYArG4wSUSBT1raXQCgByWvGyirDLyJ330vsOn/ilRv1kKIV4i4twX84aJPZA2Eyh0F6w==",
+      "version": "0.35.1",
+      "resolved": "https://registry.npmjs.org/nmr-load-save/-/nmr-load-save-0.35.1.tgz",
+      "integrity": "sha512-XFqTAgzpp0jwV65j+BbSMrvVC/nN8cW0Lmfsn4X7TyPEE5VzgZzd6I62A+2Ymd/abAwJsRGJJQsjwY7ZCv4l5A==",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1",
         "@types/lodash.merge": "^4.6.9",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "ml-tree-similarity": "^2.2.0",
     "multiplet-analysis": "^2.1.2",
     "nmr-correlation": "^2.3.3",
-    "nmr-load-save": "^0.35.0",
+    "nmr-load-save": "^0.35.1",
     "nmr-processing": "^12.8.0",
     "nmredata": "^0.9.11",
     "numeral": "^2.0.6",


### PR DESCRIPTION
chore: update nmr-load-save to version 0.35.1

close #3136