### PR TITLE
fix: allow big couplings when a range is added manually

### DIFF
--- a/src/data/data1d/Spectrum1D/ranges/detectSignals.ts
+++ b/src/data/data1d/Spectrum1D/ranges/detectSignals.ts
@@ -18,9 +18,9 @@ export default function detectSignals(
   const { from, to, frequency, nucleus, logger } = options;
 
   const { fromIndex, toIndex } = xGetFromToIndex(data.x, { from, to });
-
   const size = toIndex - fromIndex;
   if (size <= 16 || size >= MAX_LENGTH) {
+    const frequencyCluster = (to - from) * frequency;
     const ranges = xyAutoRangesPicking(data, {
       logger,
       peakPicking: {
@@ -39,7 +39,7 @@ export default function detectSignals(
         frequency,
         nucleus,
         compile: true,
-        frequencyCluster: 16,
+        frequencyCluster,
         keepPeaks: true,
         clean: 0.3,
       },


### PR DESCRIPTION
the coupling can be as big as the size of the range in Hz.