### PR TITLE
feat: display tracking for selected spectra

### DIFF
--- a/src/component/1d/SpectraLegends.tsx
+++ b/src/component/1d/SpectraLegends.tsx
@@ -16,6 +16,7 @@ import { useScale } from '../context/ScaleContext';
 import { SVGGroup } from '../elements/SVGGroup';
 import { usePanelPreferences } from '../hooks/usePanelPreferences';
 import { convertPathArrayToString } from '../utility/convertPathArrayToString';
+import { useActiveSpectra } from '../hooks/useActiveSpectra';
 
 const styles: Record<'text' | 'colorIndicator', CSSProperties> = {
   text: {
@@ -130,13 +131,19 @@ function SpectraLegends() {
     activeTab,
   );
 
+  const selectedSpectra = useActiveSpectra() || [];
+  const selectedSpectraIDs = new Set(
+    selectedSpectra.map((spectrum) => spectrum.id),
+  );
+
   if (!showLegend) return null;
 
   const spectra = data.filter(
     (spectrum) =>
       spectrum.display.isVisible &&
       xDomains[spectrum.id] &&
-      spectrum.info.nucleus === activeTab,
+      spectrum.info.nucleus === activeTab &&
+      (selectedSpectraIDs.size === 0 || selectedSpectraIDs.has(spectrum.id)),
   );
 
   return (


### PR DESCRIPTION
When one or more spectra are selected, display tracking for those specific spectra. If no spectra are selected, display tracking for all available spectra

close #3231