### PR TITLE
refactor: rename relative column header in ranges

### DIFF
--- a/src/component/1d/FloatingRanges.tsx
+++ b/src/component/1d/FloatingRanges.tsx
@@ -20,6 +20,7 @@ import { usePanelPreferences } from '../hooks/usePanelPreferences.js';
 import { useSVGUnitConverter } from '../hooks/useSVGUnitConverter.js';
 import useSpectraByActiveNucleus from '../hooks/useSpectraPerNucleus.js';
 import { useCheckExportStatus } from '../hooks/useViewportSize.js';
+import { extractChemicalElement } from '../utility/extractChemicalElement.js';
 import { formatNumber } from '../utility/formatNumber.js';
 
 const ReactRnd = styled(Rnd)`
@@ -46,44 +47,6 @@ interface RangeItem {
   integration: string;
   coupling: string;
 }
-
-const columns: Array<SVGTableColumn<RangeItem>> = [
-  {
-    accessorKey: 'delta',
-    header: 'δ (ppm)',
-    width: 100,
-    rowSpanGroupKey: 'id',
-    headerTextProps: { fontWeight: 'bold' },
-    cellBoxProps: { stroke: '#dedede', fill: 'white', fillOpacity: 0.8 },
-    headerBoxProps: { stroke: '#dedede', fill: '#E5E8EB' },
-  },
-  {
-    accessorKey: 'integration',
-    header: 'Rel. H',
-    width: 60,
-    rowSpanGroupKey: 'id',
-    headerTextProps: { fontWeight: 'bold' },
-    cellBoxProps: { stroke: '#dedede', fill: 'white', fillOpacity: 0.8 },
-    headerBoxProps: { stroke: '#dedede', fill: '#E5E8EB' },
-  },
-  {
-    accessorKey: 'multiplicity',
-    header: 'Mult.',
-    width: 60,
-    rowSpanGroupKey: 'id',
-    headerTextProps: { fontWeight: 'bold' },
-    cellBoxProps: { stroke: '#dedede', fill: 'white', fillOpacity: 0.8 },
-    headerBoxProps: { stroke: '#dedede', fill: '#E5E8EB' },
-  },
-  {
-    accessorKey: 'coupling',
-    header: 'J (Hz)',
-    width: 120,
-    headerTextProps: { fontWeight: 'bold' },
-    cellBoxProps: { stroke: '#dedede', fill: 'white', fillOpacity: 0.8 },
-    headerBoxProps: { stroke: '#dedede', fill: '#E5E8EB' },
-  },
-];
 
 function useMapRanges(ranges: Ranges['values']) {
   const output: RangeItem[] = [];
@@ -143,9 +106,54 @@ function useMapRanges(ranges: Ranges['values']) {
 }
 function InnerSVGRangesTable(props: RangesTableProps) {
   const { ranges } = props;
+  const {
+    view: {
+      spectra: { activeTab },
+    },
+  } = useChartData();
   const data = useMapRanges(ranges);
 
   if (!data) return null;
+
+  const element = extractChemicalElement(activeTab);
+
+  const columns: Array<SVGTableColumn<RangeItem>> = [
+    {
+      accessorKey: 'delta',
+      header: 'δ (ppm)',
+      width: 100,
+      rowSpanGroupKey: 'id',
+      headerTextProps: { fontWeight: 'bold' },
+      cellBoxProps: { stroke: '#dedede', fill: 'white', fillOpacity: 0.8 },
+      headerBoxProps: { stroke: '#dedede', fill: '#E5E8EB' },
+    },
+    {
+      accessorKey: 'integration',
+      header: `Rel. ${element}`,
+      width: 60,
+      rowSpanGroupKey: 'id',
+      headerTextProps: { fontWeight: 'bold' },
+      cellBoxProps: { stroke: '#dedede', fill: 'white', fillOpacity: 0.8 },
+      headerBoxProps: { stroke: '#dedede', fill: '#E5E8EB' },
+    },
+    {
+      accessorKey: 'multiplicity',
+      header: 'Mult.',
+      width: 60,
+      rowSpanGroupKey: 'id',
+      headerTextProps: { fontWeight: 'bold' },
+      cellBoxProps: { stroke: '#dedede', fill: 'white', fillOpacity: 0.8 },
+      headerBoxProps: { stroke: '#dedede', fill: '#E5E8EB' },
+    },
+    {
+      accessorKey: 'coupling',
+      header: 'J (Hz)',
+      width: 120,
+      headerTextProps: { fontWeight: 'bold' },
+      cellBoxProps: { stroke: '#dedede', fill: 'white', fillOpacity: 0.8 },
+      headerBoxProps: { stroke: '#dedede', fill: '#E5E8EB' },
+    },
+  ];
 
   return <SVGTable<RangeItem> data={data} columns={columns} />;
 }

--- a/src/component/panels/RangesPanel/RangesTable.tsx
+++ b/src/component/panels/RangesPanel/RangesTable.tsx
@@ -8,6 +8,7 @@ import { EmptyText } from '../../elements/EmptyText.js';
 import type { TableContextMenuProps } from '../../elements/ReactTable/ReactTable.js';
 import useTableSortBy from '../../hooks/useTableSortBy.js';
 import { EditRangeModal } from '../../modal/editRange/EditRangeModal.js';
+import { extractChemicalElement } from '../../utility/extractChemicalElement.js';
 import { NoDataForFid } from '../extra/placeholder/NoDataForFid.js';
 
 import RangesTableRow from './RangesTableRow.js';
@@ -76,7 +77,7 @@ function RangesTable({
   preferences,
   info,
 }: RangesTableProps) {
-  const element = activeTab?.replace(/\d/g, '');
+  const element = extractChemicalElement(activeTab);
   const { items: sortedData, isSortedDesc, onSort } = useTableSortBy(tableData);
   const data = useMapRanges(sortedData);
 

--- a/src/component/utility/extractChemicalElement.ts
+++ b/src/component/utility/extractChemicalElement.ts
@@ -1,0 +1,3 @@
+export function extractChemicalElement(isotope: string) {
+  return isotope?.replace(/\d/g, '');
+}


### PR DESCRIPTION
 - rename the relative column header in 'floating ranges' to be based on the corresponding chemical element