### PR TITLE
fix: prevent click event if the user dragged the mouse

### DIFF
--- a/src/component/EventsTrackers/BrushTracker.tsx
+++ b/src/component/EventsTrackers/BrushTracker.tsx
@@ -115,6 +115,7 @@ export function BrushTracker({
   const clickCountRef = useRef(0);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastPointRef = useRef<number>(0);
+  const isDraggingRef = useRef(false);
 
   const pointerDownHandler = useCallback(
     (event: React.PointerEvent) => {
@@ -139,7 +140,8 @@ export function BrushTracker({
       }
 
       function moveCallback(event: PointerEvent) {
-        // event.preventDefault();
+        isDraggingRef.current = true; // set flag to true to skip click event if the user dragged the mouse
+
         dispatch({
           type: 'MOVE',
           payload: {
@@ -169,6 +171,12 @@ export function BrushTracker({
 
   const clickHandler = useCallback(
     (e: React.MouseEvent) => {
+      if (isDraggingRef.current) {
+        return; // Skip click event if the user dragged the mouse
+      }
+
+      isDraggingRef.current = false;
+
       const boundingRect = e.currentTarget.getBoundingClientRect();
       const x = e.clientX - boundingRect.x;
       const y = e.clientY - boundingRect.y;

--- a/test-e2e/panels/integral.test.ts
+++ b/test-e2e/panels/integral.test.ts
@@ -80,6 +80,10 @@ test('Should Integrals Add/resize/delete', async ({ page }) => {
     // Test add two integrals
     await addIntegral(nmrium, 50, 70, 0);
     await addIntegral(nmrium, 110, 130, 1);
+
+    await expect(
+      nmrium.page.locator('_react=IntegralsSeries >> _react=Integration'),
+    ).toHaveCount(2);
   });
 
   await test.step('Resize one of the integrals ', async () => {


### PR DESCRIPTION
Playwright's mousedown, move, and mouseup events do not trigger a click event, preventing me from reproducing the issue in Playwright to write a test case.