### PR TITLE
fix: pass start and end in PPM for 'ANALYZE_SPECTRA' action

### DIFF
--- a/src/component/1d/BrushTracker1D.tsx
+++ b/src/component/1d/BrushTracker1D.tsx
@@ -173,8 +173,8 @@ export function BrushTracker1D({ children }) {
                 dispatchPreferences({
                   type: 'ANALYZE_SPECTRA',
                   payload: {
-                    start: brushData.startX,
-                    end: brushData.endX,
+                    start: brushDataInPPM.startX,
+                    end: brushDataInPPM.endX,
                     nucleus: activeTab,
                   },
                 });

--- a/src/component/panels/multipleAnalysisPanel/base/AnalysisColumnHeader.tsx
+++ b/src/component/panels/multipleAnalysisPanel/base/AnalysisColumnHeader.tsx
@@ -20,7 +20,6 @@ const styles: Record<
   container: {
     position: 'relative',
     padding: '0.15rem 0.4rem',
-    height: '100%',
   },
   deleteButton: {
     position: 'absolute',


### PR DESCRIPTION
Resolve a bug introduced by commit #b164290