### PR TITLE
fix: update OpenChemLib to v9.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "nmr-correlation": "2.3.3",
         "nmr-processing": "^18.0.1",
         "numeral": "^2.0.6",
-        "openchemlib": "^9.1.0",
+        "openchemlib": "^9.1.1",
         "openchemlib-utils": "^8.1.1",
         "papaparse": "^5.5.2",
         "react-d3-utils": "^3.0.0",
@@ -9991,9 +9991,9 @@
       }
     },
     "node_modules/openchemlib": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/openchemlib/-/openchemlib-9.1.0.tgz",
-      "integrity": "sha512-lCDnzX5jUfDO5VvHcxGu18XpSL/nHwPdB70O8Cp/nohxo4TQaCsdG7lcxaPyB1eV5Ep2rPm28ZkRhszMf7FUVA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/openchemlib/-/openchemlib-9.1.1.tgz",
+      "integrity": "sha512-KL+0qMz1mXFUnNz61OkM5G+FfsP2xcr1lH5tQjHPhRU6+lj8pOjZbyv6GRBK8n+EYMGPfSvLsLui9K2nKcLBtg==",
       "license": "BSD-3-Clause"
     },
     "node_modules/openchemlib-utils": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "nmr-correlation": "2.3.3",
     "nmr-processing": "^18.0.1",
     "numeral": "^2.0.6",
-    "openchemlib": "^9.1.0",
+    "openchemlib": "^9.1.1",
     "openchemlib-utils": "^8.1.1",
     "papaparse": "^5.5.2",
     "react-d3-utils": "^3.0.0",


### PR DESCRIPTION
Greatly improves rendering of the molecule editor on hidpi screens.

Release-as: v0.63.0
