### PR TITLE
chore: move blueprintjs to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,9 +11,6 @@
       "dependencies": {
         "@atlaskit/pragmatic-drag-and-drop": "^1.7.4",
         "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
-        "@blueprintjs/core": "^6.2.0",
-        "@blueprintjs/icons": "^6.1.0",
-        "@blueprintjs/select": "^6.0.2",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
         "@hookform/resolvers": "^5.2.1",
@@ -63,6 +60,9 @@
         "yup": "^1.7.0"
       },
       "devDependencies": {
+        "@blueprintjs/core": "^6.2.0",
+        "@blueprintjs/icons": "^6.1.0",
+        "@blueprintjs/select": "^6.0.2",
         "@playwright/test": "^1.54.2",
         "@simbathesailor/use-what-changed": "^2.0.0",
         "@types/d3": "^7.4.3",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "url": "git+https://github.com/cheminfo/nmrium.git"
   },
   "peerDependencies": {
+    "@blueprintjs/core": "^6.0.0",
+    "@blueprintjs/icons": "^6.0.0",
+    "@blueprintjs/select": "^6.0.0",
     "react": ">=18.0.0",
     "react-dom": ">=18.0.0"
   },
@@ -59,9 +62,6 @@
   "dependencies": {
     "@atlaskit/pragmatic-drag-and-drop": "^1.7.4",
     "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
-    "@blueprintjs/core": "^6.2.0",
-    "@blueprintjs/icons": "^6.1.0",
-    "@blueprintjs/select": "^6.0.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
     "@hookform/resolvers": "^5.2.1",
@@ -111,6 +111,9 @@
     "yup": "^1.7.0"
   },
   "devDependencies": {
+    "@blueprintjs/core": "^6.2.0",
+    "@blueprintjs/icons": "^6.1.0",
+    "@blueprintjs/select": "^6.0.2",
     "@playwright/test": "^1.54.2",
     "@simbathesailor/use-what-changed": "^2.0.0",
     "@types/d3": "^7.4.3",


### PR DESCRIPTION
- move @blueprintjs/core,  @blueprintjs/icons and @blueprintjs/select to peerDependencies and devDependencies