### PR TITLE
fix: only render dialog contents styles with fallback

### DIFF
--- a/src/component/modal/aboutUs/AboutUsModal.tsx
+++ b/src/component/modal/aboutUs/AboutUsModal.tsx
@@ -14,9 +14,8 @@ import AboutUsZakodium from './AboutUsZakodium.js';
 const FallbackDialogContents = styled.div`
   display: flex;
   flex-direction: column;
-  user-select: none;
-
   padding: 20px;
+  user-select: none;
 
   button:focus {
     outline: none;


### PR DESCRIPTION
Otherwise it's more difficult to style the slot from an external plugin.
