### PR TITLE
fix: multiple call to `readNMRiumObject` into `NMRiumStateProvider`

### DIFF
--- a/src/component/context/LoggerContext.tsx
+++ b/src/component/context/LoggerContext.tsx
@@ -55,8 +55,7 @@ export function LoggerProvider({ children }: LoggerProviderProps) {
   const [logsHistory, setLogsHistory] = useState<LogEntry[]>([]);
   const [isLogHistoryOpened, openLogHistory] = useState(false);
   const popupLoggingLevelRef = useRef<LogEntry['levelLabel']>();
-
-  const loggerRef = useRef<FifoLogger>(new FifoLogger());
+  const [logger] = useState(() => new FifoLogger());
 
   useEffect(() => {
     function handleLogger({ detail: { logs } }: ChangeEvent) {
@@ -74,20 +73,18 @@ export function LoggerProvider({ children }: LoggerProviderProps) {
       }
       setLogsHistory(logs.slice());
     }
-    const loggerInstance = loggerRef.current;
 
-    loggerInstance.addEventListener('change', handleLogger);
-
+    logger.addEventListener('change', handleLogger);
     return () => {
-      loggerInstance.removeEventListener('change', handleLogger);
+      logger.removeEventListener('change', handleLogger);
     };
-  }, []);
+  }, [logger]);
 
   useEffect(() => {
     if (loggingLevel) {
-      loggerRef.current.setLevel(loggingLevel);
+      logger.setLevel(loggingLevel);
     }
-  }, [loggingLevel]);
+  }, [logger, loggingLevel]);
 
   const markAsRead = useCallback(() => {
     if (logsHistory.length > 0) {
@@ -98,12 +95,12 @@ export function LoggerProvider({ children }: LoggerProviderProps) {
 
   const loggerState = useMemo(() => {
     return {
-      logger: loggerRef.current,
+      logger,
       logsHistory,
       markAsRead,
       lastReadLogId,
     };
-  }, [lastReadLogId, logsHistory, markAsRead]);
+  }, [logger, lastReadLogId, logsHistory, markAsRead]);
 
   useEffect(() => {
     popupLoggingLevelRef.current = popupLoggingLevel;

--- a/src/component/context/PreferencesContext.tsx
+++ b/src/component/context/PreferencesContext.tsx
@@ -1,20 +1,23 @@
+import type { Dispatch } from 'react';
 import { createContext, useContext, useMemo } from 'react';
 
 import type {
+  PreferencesActions,
   PreferencesState,
   WorkspaceWithSource,
 } from '../reducer/preferences/preferencesReducer.js';
-import { preferencesInitialState } from '../reducer/preferences/preferencesReducer.js';
 import { isReadOnlyWorkspace } from '../reducer/preferences/utilities/isReadOnlyWorkspace.js';
 
-interface PreferencesContextData extends PreferencesState {
+export interface PreferencesStateContext extends PreferencesState {
+  dispatch: Dispatch<PreferencesActions>;
+}
+
+interface PreferencesContextData extends PreferencesStateContext {
   isCurrentWorkspaceReadOnly: boolean;
   current: WorkspaceWithSource;
 }
 
-const PreferencesContext = createContext<PreferencesState>(
-  preferencesInitialState,
-);
+const PreferencesContext = createContext<PreferencesStateContext | null>(null);
 export const PreferencesProvider = PreferencesContext.Provider;
 
 export function usePreferences(): PreferencesContextData {

--- a/src/component/main/InnerNMRium.tsx
+++ b/src/component/main/InnerNMRium.tsx
@@ -8,6 +8,7 @@ import { CoreProvider } from '../context/CoreContext.js';
 import { GlobalProvider } from '../context/GlobalContext.js';
 import { KeyModifiersProvider } from '../context/KeyModifierContext.js';
 import { LoggerProvider } from '../context/LoggerContext.js';
+import type { PreferencesStateContext } from '../context/PreferencesContext.js';
 import { PreferencesProvider } from '../context/PreferencesContext.js';
 import { SortSpectraProvider } from '../context/SortSpectraContext.js';
 import { ToasterProvider } from '../context/ToasterContext.js';
@@ -66,6 +67,10 @@ export function InnerNMRium(props: InnerNMRiumProps) {
     initPreferencesState,
   );
 
+  const preferencesProviderValue = useMemo<PreferencesStateContext>(() => {
+    return { ...preferencesState, dispatch: dispatchPreferences };
+  }, [preferencesState]);
+
   useEffect(() => {
     rootRef.current?.focus();
   }, [isFullScreen]);
@@ -79,7 +84,6 @@ export function InnerNMRium(props: InnerNMRiumProps) {
         workspace,
         customWorkspaces,
         currentWorkspace: settings?.currentWorkspace,
-        dispatch: dispatchPreferences,
       },
     });
   }, [customWorkspaces, preferences, workspace]);
@@ -99,7 +103,7 @@ export function InnerNMRium(props: InnerNMRiumProps) {
               viewerRef: viewerRef.current,
             }}
           >
-            <PreferencesProvider value={preferencesState}>
+            <PreferencesProvider value={preferencesProviderValue}>
               <LoggerProvider>
                 <KeyModifiersProvider>
                   <ToasterProvider>

--- a/src/component/reducer/preferences/actions/initPreferences.ts
+++ b/src/component/reducer/preferences/actions/initPreferences.ts
@@ -16,7 +16,6 @@ function getWorkspace(
 export function initPreferences(draft: Draft<PreferencesState>, action: any) {
   if (action.payload) {
     const {
-      dispatch,
       workspace,
       customWorkspaces: cw,
       preferences,
@@ -77,7 +76,5 @@ export function initPreferences(draft: Draft<PreferencesState>, action: any) {
         ),
       };
     }
-
-    draft.dispatch = dispatch;
   }
 }

--- a/src/component/reducer/preferences/preferencesReducer.ts
+++ b/src/component/reducer/preferences/preferencesReducer.ts
@@ -1,5 +1,6 @@
 import type {
   ACSExportOptions,
+  CustomWorkspaces,
   ExportPreferences,
   ExportSettings,
   MultipleSpectraAnalysisPreferences,
@@ -70,10 +71,11 @@ export interface Settings {
 type InitPreferencesAction = ActionType<
   'INIT_PREFERENCES',
   {
-    display: NMRiumPreferences;
-    workspace: NMRiumWorkspace;
-    customWorkspaces: Record<string, Workspace>;
-    dispatch: any;
+    preferences: NMRiumPreferences | undefined;
+    display?: NMRiumPreferences;
+    workspace: NMRiumWorkspace | undefined;
+    customWorkspaces: CustomWorkspaces | undefined;
+    currentWorkspace: Settings['currentWorkspace'] | undefined;
   }
 >;
 
@@ -168,7 +170,7 @@ export type TogglePanelAction = ActionType<
   }
 >;
 
-type PreferencesActions =
+export type PreferencesActions =
   | InitPreferencesAction
   | SetPreferencesAction
   | SetPanelsPreferencesAction
@@ -198,7 +200,6 @@ export interface PreferencesState {
   // TODO: A lot of places set this to Required<WorkspacePreferences>, which is a subset of this type
   workspaces: WorkspacesWithSource;
   originalWorkspaces: WorkspacesWithSource;
-  dispatch: (action?: PreferencesActions) => void;
   workspace: {
     current: NMRiumWorkspace;
     base: NMRiumWorkspace | null;
@@ -209,7 +210,6 @@ export const preferencesInitialState: PreferencesState = {
   version: CURRENT_EXPORT_VERSION,
   workspaces: {},
   originalWorkspaces: {},
-  dispatch: () => null,
   workspace: {
     current: 'default',
     base: null,
@@ -319,8 +319,7 @@ function innerPreferencesReducer(
       return draft;
   }
 }
-const preferencesReducer: Reducer<PreferencesState, any> = produce(
-  innerPreferencesReducer,
-);
+const preferencesReducer: Reducer<PreferencesState, PreferencesActions> =
+  produce(innerPreferencesReducer);
 
 export default preferencesReducer;


### PR DESCRIPTION
It was due to `dispatchPreferences` change.
I refactor `PreferencesContext`, the dispatch method is no longer put in state managed by the reducer. Instead, a `useMemo` merge the `preferenceState` with `dispatch` to bind it as `PreferencesProvider` `value`.

* tweak `LoggerProvider`, replace ref invoking `new FifoLogger()` at each render, by a `useState` with init method.