### PR TITLE
test: do not use global type declaration for BoundingBox

### DIFF
--- a/test-e2e/BoundingBox.d.ts
+++ b/test-e2e/BoundingBox.d.ts
@@ -1,6 +1,0 @@
-interface BoundingBox {
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}

--- a/test-e2e/NmriumPage/NmriumPageViewer.ts
+++ b/test-e2e/NmriumPage/NmriumPageViewer.ts
@@ -1,5 +1,7 @@
 import type { Locator, Page } from '@playwright/test';
 
+import type { BoundingBox } from '../playwright_types.ts';
+
 interface MoveMouseOptions {
   x?: number;
   y?: number;

--- a/test-e2e/panels/integral.test.ts
+++ b/test-e2e/panels/integral.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import NmriumPage from '../NmriumPage/index.js';
+import type { BoundingBox } from '../playwright_types.ts';
 
 async function addIntegral(
   nmrium: NmriumPage,

--- a/test-e2e/panels/ranges.test.ts
+++ b/test-e2e/panels/ranges.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from '@playwright/test';
 
 import NmriumPage from '../NmriumPage/index.js';
+import type { BoundingBox } from '../playwright_types.ts';
 
 async function addRange(
   nmrium: NmriumPage,

--- a/test-e2e/playwright_types.ts
+++ b/test-e2e/playwright_types.ts
@@ -1,0 +1,6 @@
+import type { Locator } from '@playwright/test';
+
+export type BoundingBox = Exclude<
+  Awaited<ReturnType<Locator['boundingBox']>>,
+  null
+>;


### PR DESCRIPTION
It leaks into `src` where we can use it by mistake.
