### PR TITLE
fix: resolve NextPrev slider width measurement in modals

### DIFF
--- a/src/component/modal/changeSum/ChangeSumModal.tsx
+++ b/src/component/modal/changeSum/ChangeSumModal.tsx
@@ -35,7 +35,7 @@ export default function ChangeSumModal(props: ChangeSumModalProps) {
         <Dialog
           isOpen
           onClose={closeDialog}
-          style={{ width: 500 }}
+          style={{ width: 500, minHeight: 450 }}
           title={
             currentSum
               ? `Set new ${sumType} sum (Current: ${currentSum.toFixed(2)})`

--- a/src/component/modal/changeSum/SelectMolecule.tsx
+++ b/src/component/modal/changeSum/SelectMolecule.tsx
@@ -87,29 +87,29 @@ export default function SelectMolecule<
     [setValue],
   );
 
-  return (
-    <div>
-      {element && molecules && molecules.length > 0 ? (
-        <Container>
-          <Title>Select a molecule as reference!</Title>
+  if (element && molecules && molecules.length > 0) {
+    return (
+      <Container>
+        <Title>Select a molecule as reference!</Title>
 
-          <SelectionContainer>
-            <MoleculeSelection
-              index={currentIndex}
-              molecules={molecules}
-              onChange={onChangeMoleculeSelectionHandler}
-            />
-            <SumValue>
-              New sum for {element} will be {newSum}!
-            </SumValue>
-          </SelectionContainer>
-        </Container>
-      ) : (
-        <EmptyText color={invalid ? 'red' : 'black'}>
-          You have to Select a spectrum and Add a molecule from the Structure
-          panel to select as a reference!
-        </EmptyText>
-      )}
-    </div>
+        <SelectionContainer>
+          <MoleculeSelection
+            index={currentIndex}
+            molecules={molecules}
+            onChange={onChangeMoleculeSelectionHandler}
+          />
+          <SumValue>
+            New sum for {element} will be {newSum}!
+          </SumValue>
+        </SelectionContainer>
+      </Container>
+    );
+  }
+
+  return (
+    <EmptyText color={invalid ? 'red' : 'black'}>
+      You have to Select a spectrum and Add a molecule from the Structure panel
+      to select as a reference!
+    </EmptyText>
   );
 }


### PR DESCRIPTION
Replace react-d3-utils ResizeObserver with manual implementation using useLayoutEffect to fix incorrect `width` calculation when component is rendered inside modals.

The previous implementation measured `width` before the modal was fully rendered