### PR TITLE
fix: use absolute sum for 1D projections

### DIFF
--- a/src/data/data2d/Spectrum2D/getMissingProjection.ts
+++ b/src/data/data2d/Spectrum2D/getMissingProjection.ts
@@ -16,13 +16,13 @@ export function getProjection(datum: NmrData2DFt['rr'], index: number) {
   if (index === 1) {
     for (let i = 0; i < datum.z.length; i++) {
       for (let j = 0; j < datum.z[0].length; j++) {
-        projection[i] += datum.z[i][j];
+        projection[i] += Math.abs(datum.z[i][j]);
       }
     }
   } else {
     for (let i = 0; i < datum.z[0].length; i++) {
       for (const z of datum.z) {
-        projection[i] += z[i];
+        projection[i] += Math.abs(z[i]);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Use `Math.abs()` when summing 2D spectrum values to generate 1D projections, preventing positive and negative values from canceling each other out

## Test plan

- [ ] Open a 2D spectrum without 1D projections
- [ ] Click "Add missing projection" 
- [ ] Verify the generated 1D projections show correct absolute-sum intensities