### PR TITLE
fix: wrong type stored when changing equivalence value in summary panel

### DIFF
--- a/src/component/panels/SummaryPanel/CorrelationTable/CorrelationTableRow.tsx
+++ b/src/component/panels/SummaryPanel/CorrelationTable/CorrelationTableRow.tsx
@@ -76,7 +76,7 @@ function CorrelationTableRow(props: CorrelationTableRowProps) {
 
   const onSaveEquivalencesHandler = useCallback(
     (e: any) => {
-      onSaveEditEquivalences(correlation, e.target.value);
+      onSaveEditEquivalences(correlation, Number(e.target.value));
     },
     [correlation, onSaveEditEquivalences],
   );


### PR DESCRIPTION
In summary panel, the type of the entered value from equivalence field cell is stored as a string value which is not correct and causes problems within the calculation. It should be a numeric value.