### PR TITLE
feat: show processings in error

### DIFF
--- a/src/component/panels/filtersPanel/processings/processing_item.tsx
+++ b/src/component/panels/filtersPanel/processings/processing_item.tsx
@@ -85,14 +85,18 @@ export function ProcessingItem(props: ProcessingItemProps) {
     liveEditRef.current = liveEdit;
   }, [liveEdit]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    return () => processingsMutationsRef.current.resetLiveChange();
+  }, [isOpen]);
+
   function onReorder(sourceIndex: number, targetIndex: number) {
     void processingsMutations.reorder(sourceIndex, targetIndex);
   }
 
   function toggleSection(operationId: string) {
-    setOpenedOperation((openedOperation) =>
-      openedOperation === operationId ? undefined : operationId,
-    );
+    setOpenedOperation(isOpen ? undefined : operationId);
   }
 
   return (

--- a/src/component/panels/filtersPanel/processings/processing_item.tsx
+++ b/src/component/panels/filtersPanel/processings/processing_item.tsx
@@ -21,10 +21,8 @@ type SPO = SpectrumProcessingOperation<unknown, unknown>;
 interface ProcessingItemProps {
   operation: SPO;
   operationIndex: number;
-  selectedProcessing: {
-    operatorId?: string;
-    operationId?: string;
-  };
+  isOpen: boolean;
+  isAfterOpen: boolean;
   processingsMutations: ProcessingsMutations;
   setOpenedOperation: Dispatch<SetStateAction<SPO['uid'] | undefined>>;
 }
@@ -33,7 +31,8 @@ export function ProcessingItem(props: ProcessingItemProps) {
   const {
     operation,
     operationIndex,
-    selectedProcessing,
+    isOpen,
+    isAfterOpen,
     processingsMutations,
     setOpenedOperation,
   } = props;
@@ -41,9 +40,6 @@ export function ProcessingItem(props: ProcessingItemProps) {
   const core = useCore();
 
   const operatorUI = core.slotOperator(operation.operatorId);
-  const isOpen =
-    selectedProcessing.operatorId === operation.operatorId ||
-    selectedProcessing.operationId === operation.uid;
   const isEditable = operatorUI?.isEditable;
   const isLiveEditable = operatorUI?.isLiveEditable;
 
@@ -123,6 +119,14 @@ export function ProcessingItem(props: ProcessingItemProps) {
           operation={operation}
         />
       }
+      headerStyle={getHeaderStyle({
+        isOpen,
+        operation:
+          isOpen && liveEdit.value?.checked
+            ? liveOperationRef.current
+            : operation,
+        isAfterOpen,
+      })}
     >
       <Sections.Body style={{ paddingBottom: '120px' }}>
         <CoreOperatorExpanded
@@ -193,4 +197,30 @@ function OperationFallback(props: OperationFallbackProps) {
   }
 
   return <ObjectInspector data={{ settings, options }} />;
+}
+
+interface GetHeaderStyleOptions {
+  operation: SpectrumProcessingOperation<unknown, unknown>;
+  isOpen: boolean;
+  isAfterOpen: boolean;
+}
+
+function getHeaderStyle(options: GetHeaderStyleOptions) {
+  const { operation, isOpen, isAfterOpen } = options;
+
+  const { error } = operation;
+
+  if (error) {
+    return { backgroundColor: '#ea8f8f' };
+  }
+
+  if (isOpen) {
+    return { backgroundColor: '#c2ea8f' };
+  }
+
+  if (isAfterOpen) {
+    return { opacity: 0.5 };
+  }
+
+  return {};
 }

--- a/src/component/panels/filtersPanel/processings/processing_item.tsx
+++ b/src/component/panels/filtersPanel/processings/processing_item.tsx
@@ -1,5 +1,6 @@
+import styled from '@emotion/styled';
 import type { SpectrumProcessingOperation } from '@zakodium/nmrium-core';
-import type { Dispatch, SetStateAction } from 'react';
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
 import { useEffect, useRef } from 'react';
 import { ObjectInspector } from 'react-inspector';
 
@@ -179,10 +180,37 @@ export function ProcessingItem(props: ProcessingItemProps) {
             )
           }
         </CoreOperatorExpanded>
+        {operation.error && <ErrorRenderer>{operation.error}</ErrorRenderer>}
       </Sections.Body>
     </Sections.Item>
   );
 }
+
+interface ErrorRendererProps {
+  children: ReactNode;
+}
+function ErrorRenderer(props: ErrorRendererProps) {
+  return (
+    <Pre>
+      <Code>{props.children}</Code>
+    </Pre>
+  );
+}
+
+const Pre = styled.pre`
+  display: block;
+  margin-inline: -10px;
+  padding-inline: 10px;
+  padding-block: 5px;
+  background: #ea8f8f;
+`;
+
+const Code = styled.code`
+  display: block;
+  max-width: 100%;
+  overflow: auto;
+  white-space: normal;
+`;
 
 interface OperationFallbackProps {
   operation: SpectrumProcessingOperation<unknown, unknown>;

--- a/src/component/panels/filtersPanel/processings/processing_item.tsx
+++ b/src/component/panels/filtersPanel/processings/processing_item.tsx
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled';
 import type { SpectrumProcessingOperation } from '@zakodium/nmrium-core';
 import type { Dispatch, ReactNode, SetStateAction } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { ObjectInspector } from 'react-inspector';
 
 import { useCore } from '../../../context/CoreContext.tsx';
@@ -53,8 +53,14 @@ export function ProcessingItem(props: ProcessingItemProps) {
   const processingsMutationsRef = useRef(processingsMutations);
   processingsMutationsRef.current = processingsMutations;
 
+  const [liveOperation, setLiveOperation] = useState<SPO>(() => ({
+    ...operation,
+    options: undefined,
+  }));
+
   const liveOperationRef =
-    useRef<SpectrumProcessingOperation<unknown, unknown>>(operation);
+    useRef<SpectrumProcessingOperation<unknown, unknown>>(liveOperation);
+  liveOperationRef.current = liveOperation;
 
   // track liveEdit changes to prepare / reset / apply live changes
   useEffect(() => {
@@ -127,9 +133,7 @@ export function ProcessingItem(props: ProcessingItemProps) {
       headerStyle={getHeaderStyle({
         isOpen,
         operation:
-          isOpen && liveEdit.value?.checked
-            ? liveOperationRef.current
-            : operation,
+          isOpen && liveEdit.value?.checked ? liveOperation : operation,
         isAfterOpen,
       })}
     >
@@ -164,7 +168,7 @@ export function ProcessingItem(props: ProcessingItemProps) {
             if (!liveEdit.value?.checked) return;
 
             liveOperation = { ...liveOperation, options: undefined };
-            liveOperationRef.current = liveOperation;
+            setLiveOperation(liveOperation);
 
             void processingsMutations.applyLiveChange(
               liveOperation,

--- a/src/component/panels/filtersPanel/processings_sections_panel.tsx
+++ b/src/component/panels/filtersPanel/processings_sections_panel.tsx
@@ -72,6 +72,29 @@ export function ProcessingsSectionsPanel() {
     spectrum?.processings,
   ]);
 
+  const processingsStatus = useMemo(() => {
+    const processings: Array<{
+      operation: SpectrumProcessingOperation<unknown, unknown>;
+      isOpen: boolean;
+      isAfterOpen: boolean;
+    }> = [];
+    let isAfterOpen = false;
+
+    for (const operation of spectrum?.processings ?? []) {
+      const isOpen =
+        selectedProcessing.operatorId === operation.operatorId ||
+        selectedProcessing.operationId === operation.uid;
+
+      processings.push({ isOpen, isAfterOpen, operation });
+
+      if (isOpen) {
+        isAfterOpen = true;
+      }
+    }
+
+    return processings;
+  }, [selectedProcessing, spectrum?.processings]);
+
   function handleDeleteFilter() {
     const buttons: AlertButton[] = [
       {
@@ -103,16 +126,19 @@ export function ProcessingsSectionsPanel() {
       {processings.length === 0 && <EmptyText text="No Processings" />}
       {processings.length > 0 && (
         <Sections isOverflow renderActiveSectionContentOnly>
-          {processings?.map((operation, index) => (
-            <ProcessingItem
-              key={operation.uid}
-              operation={operation}
-              operationIndex={index}
-              selectedProcessing={selectedProcessing}
-              setOpenedOperation={setOpenedOperation}
-              processingsMutations={processingsMutations}
-            />
-          ))}
+          {processingsStatus.map(
+            ({ operation, isOpen, isAfterOpen }, index) => (
+              <ProcessingItem
+                key={operation.uid}
+                operation={operation}
+                operationIndex={index}
+                isOpen={isOpen}
+                isAfterOpen={isAfterOpen}
+                setOpenedOperation={setOpenedOperation}
+                processingsMutations={processingsMutations}
+              />
+            ),
+          )}
         </Sections>
       )}
     </>


### PR DESCRIPTION
* Operation item (not the expanded part) in error have a red background
  * green when is open (not in error)
  * greyed-out when is after the opened one
  It is a restoration of the filters controls
* display the error message at the end of the Expanded section
* fix live procesings reset. Handle external close with effect to reset  live processings.