### PR TITLE
feat: show nucleus selector when no spectrum is loaded

### DIFF
--- a/src/component/panels/databasePanel/DatabasePanel.tsx
+++ b/src/component/panels/databasePanel/DatabasePanel.tsx
@@ -46,6 +46,26 @@ import DatabaseTable from './DatabaseTable.js';
 
 export type Databases = Array<LocalDatabase | Database>;
 
+function resolveNucleus(
+  nucleus: string | undefined,
+  currentPick: string | undefined,
+  distinctNuclei: string[],
+): string | undefined {
+  if (nucleus) return nucleus;
+  if (currentPick && distinctNuclei.includes(currentPick)) return currentPick;
+  return distinctNuclei[0];
+}
+
+function getDistinctNuclei(entries: DatabaseNMREntry[]): string[] {
+  const nuclei = new Set<string>();
+  for (const record of entries) {
+    if (record.nucleus) {
+      nuclei.add(record.nucleus);
+    }
+  }
+  return Array.from(nuclei);
+}
+
 function getMolfile(options: {
   ocl?: { idCode?: string; coordinates?: string };
   smiles?: string;
@@ -65,7 +85,7 @@ function getMolfile(options: {
 }
 
 interface DatabaseInnerProps {
-  nucleus: string;
+  nucleus?: string;
   selectedTool: string;
   databases: Databases;
   defaultDatabase: string;
@@ -125,7 +145,13 @@ function DatabasePanelInner({
   const dispatch = useDispatch();
   const toaster = useToaster();
 
-  const format = useFormatNumberByNucleus(nucleus);
+  const [availableNuclei, setAvailableNuclei] = useState<string[]>([]);
+  const [selectedNucleus, setSelectedNucleus] = useState<string | undefined>(
+    nucleus,
+  );
+  const effectiveNucleus = nucleus ?? selectedNucleus;
+
+  const format = useFormatNumberByNucleus(effectiveNucleus);
   const [isFlipped, setFlipStatus] = useState(false);
   const [
     isOpenSearchByStructure,
@@ -133,16 +159,20 @@ function DatabasePanelInner({
     closeSearchByStructure,
   ] = useOnOff(false);
   const settingRef = useRef<SettingsRef | null>(null);
+
   const [keywords, setKeywords] =
     useState<DatabaseSearchKeywords>(emptyKeywords);
+  const [idCode, setIdCode] = useState<string>();
+
   const databaseInstance = useRef<InitiateDatabaseResult | null>(null);
   const databaseDataRef = useRef<DatabaseNMREntry[]>([]);
+  const { getModifiersKey, primaryKeyIdentifier } = useMapKeyModifiers();
+
   const [result, setResult] = useState<DatabaseSearchResultEntry>({
     data: [],
     databases: [],
     solvents: [],
   });
-  const [idCode, setIdCode] = useState<string>();
 
   function settingsPanelHandler() {
     setFlipStatus((flag) => !flag);
@@ -150,51 +180,145 @@ function DatabasePanelInner({
 
   async function saveSettingHandler() {
     const isSettingValid = await settingRef.current?.saveSetting();
-    if (isSettingValid) {
-      setFlipStatus(false);
-    }
+    if (isSettingValid) setFlipStatus(false);
   }
 
-  const search = useCallback(
-    (solvents?: any[]) => {
-      const { solvent, searchKeywords } = keywords;
-      if (databaseInstance.current) {
-        const keywords = mapKeywordsToArray(searchKeywords, solvent);
-        const data = databaseInstance.current.search({ keywords, idCode });
-        setResult((prevResult) => ({
-          ...prevResult,
-          data,
-          ...(solvents && { solvents }),
-        }));
-      }
+  const runSearch = useCallback(
+    (options?: {
+      keywords?: DatabaseSearchKeywords;
+      idCode?: string;
+      solvents?: any[];
+    }) => {
+      const instance = databaseInstance.current;
+      if (!instance) return;
+
+      const {
+        keywords: overrideKeywords,
+        idCode: overrideIdCode,
+        solvents,
+      } = options ?? {};
+
+      const { solvent, searchKeywords } = overrideKeywords ?? keywords;
+      const effectiveIdCode =
+        overrideIdCode !== undefined ? overrideIdCode : idCode;
+
+      const keywordArray = mapKeywordsToArray(searchKeywords, solvent);
+      const data = instance.search({
+        keywords: keywordArray,
+        idCode: effectiveIdCode,
+      });
+
+      setResult((prev) => ({
+        ...prev,
+        data,
+        ...(solvents && { solvents }),
+      }));
     },
-    [idCode, keywords],
+    [keywords, idCode],
+  );
+  const buildInstanceAndSearch = useCallback(
+    async (data: DatabaseNMREntry[], nucleusToUse: string) => {
+      const hideLoading = await toaster.showAsyncLoading({
+        message: 'Loading the database',
+      });
+
+      databaseInstance.current = initiateDatabase(data, nucleusToUse);
+      const solvents = mapSolventsToSelect(
+        databaseInstance.current.getSolvents(),
+      );
+
+      setKeywords(emptyKeywords);
+      setIdCode(undefined);
+      runSearch({ keywords: emptyKeywords, solvents });
+      hideLoading();
+    },
+    [toaster, runSearch],
   );
 
-  useEffect(() => {
-    if (!databaseInstance.current) return;
+  const handleChangeDatabase = useCallback(
+    (databaseKey: any) => {
+      const database = databases.find((item) => item.key === databaseKey);
 
-    const { solvent, searchKeywords } = keywords;
-    const runner = async () => {
-      if (databaseInstance.current) {
-        const hideLoading = await toaster.showAsyncLoading({
-          message: 'Preparing of the Result',
-        });
-        if (solvent === '-1' && !searchKeywords) {
-          const solvents = mapSolventsToSelect(
-            databaseInstance.current.getSolvents(),
-          );
-          search(solvents);
+      setTimeout(async () => {
+        let data: DatabaseNMREntry[];
+
+        if (database?.url) {
+          const { url, label } = database;
+          const hideLoading = await toaster.showAsyncLoading({
+            message: `load ${label} database`,
+          });
+          try {
+            const records = await fetch(url).then((r) => r.json());
+            data = records.map((record: any) => ({ ...record, baseURL: url }));
+          } catch {
+            toaster.show({
+              message: `Failed to load ${url}`,
+              intent: 'danger',
+            });
+            hideLoading();
+            return;
+          } finally {
+            hideLoading();
+          }
         } else {
-          search();
+          data =
+            ((database as LocalDatabase)?.value as DatabaseNMREntry[]) ?? [];
         }
-        hideLoading();
-      }
-    };
 
-    void runner();
-  }, [idCode, keywords, search, toaster]);
-  const { getModifiersKey, primaryKeyIdentifier } = useMapKeyModifiers();
+        databaseDataRef.current = data;
+
+        const distinctNuclei = getDistinctNuclei(data);
+        setAvailableNuclei(distinctNuclei);
+
+        const nucleusToUse = resolveNucleus(
+          nucleus,
+          selectedNucleus,
+          distinctNuclei,
+        );
+        setSelectedNucleus(nucleusToUse);
+
+        if (!nucleusToUse) {
+          databaseInstance.current = null;
+          setKeywords(emptyKeywords);
+          setResult({ data: [], databases: [], solvents: [] });
+          return;
+        }
+
+        await buildInstanceAndSearch(data, nucleusToUse);
+      }, 0);
+    },
+    [databases, nucleus, selectedNucleus, toaster, buildInstanceAndSearch],
+  );
+
+  const handleNucleusChange = useCallback(
+    (newNucleus: string) => {
+      setSelectedNucleus(newNucleus);
+      void buildInstanceAndSearch(databaseDataRef.current, newNucleus);
+    },
+    [buildInstanceAndSearch],
+  );
+
+  const handleKeywordsChange = useCallback(
+    (partial: Partial<DatabaseSearchKeywords>) => {
+      setKeywords((prev) => {
+        const next = { ...prev, ...partial };
+        runSearch({ keywords: next });
+        return next;
+      });
+    },
+    [runSearch],
+  );
+
+  const searchByStructureHandler = useCallback(
+    (idCodeValue: string) => {
+      const molecule = Molecule.fromIDCode(idCodeValue);
+      const atoms = molecule.getAllAtoms();
+      const nextIdCode = atoms > 0 ? idCodeValue : '';
+      setIdCode(nextIdCode);
+      runSearch({ idCode: nextIdCode });
+    },
+    [runSearch],
+  );
 
   useEffect(() => {
     function handle(event: BrushTrackerData & { range: [number, number] }) {
@@ -211,11 +335,15 @@ function DatabasePanelInner({
           ? prevState.searchKeywords.split(' ')
           : [];
         const [from, to] = event.range;
-        const searchKeywords = [
-          ...oldKeywords,
-          `delta:${format(from)}..${format(to)}`,
-        ].join(' ');
-        return { ...prevState, searchKeywords };
+        const nextKeywords = {
+          ...prevState,
+          searchKeywords: [
+            ...oldKeywords,
+            `delta:${format(from)}..${format(to)}`,
+          ].join(' '),
+        };
+        runSearch({ keywords: nextKeywords });
+        return nextKeywords;
       });
     }
 
@@ -224,87 +352,16 @@ function DatabasePanelInner({
     return () => {
       Events.off('brushEnd', handle);
     };
-  }, [format, getModifiersKey, primaryKeyIdentifier, selectedTool]);
-
-  useEffect(() => {
-    if (!databaseInstance.current) return;
-
-    const runner = async () => {
-      const hideLoading = await toaster.showAsyncLoading({
-        message: 'Loading the database',
-      });
-
-      databaseInstance.current = initiateDatabase(
-        databaseDataRef.current,
-        nucleus,
-      );
-      hideLoading();
-      setKeywords({ ...emptyKeywords });
-    };
-
-    void runner();
-  }, [nucleus, toaster]);
-
-  const handleChangeDatabase = useCallback(
-    (databaseKey: any) => {
-      const database = databases.find((item) => item.key === databaseKey);
-
-      setTimeout(async () => {
-        if (database?.url) {
-          const { url, label } = database;
-
-          const hideLoading = await toaster.showAsyncLoading({
-            message: `load ${label} database`,
-          });
-
-          try {
-            databaseDataRef.current = await fetch(url)
-              .then((response) => response.json())
-              .then((databaseRecords: any) =>
-                databaseRecords.map((record: any) => ({
-                  ...record,
-                  baseURL: url,
-                })),
-              );
-          } catch {
-            toaster.show({
-              message: `Failed to load ${url}`,
-              intent: 'danger',
-            });
-          } finally {
-            hideLoading();
-          }
-        } else {
-          databaseDataRef.current = (database as LocalDatabase)
-            ?.value as DatabaseNMREntry[];
-        }
-
-        const hideLoading = await toaster.showAsyncLoading({
-          message: 'Loading the database',
-        });
-
-        databaseInstance.current = initiateDatabase(
-          databaseDataRef.current,
-          nucleus,
-        );
-
-        setKeywords({ ...emptyKeywords });
-
-        hideLoading();
-      }, 0);
-    },
-    [databases, nucleus, toaster],
-  );
+  }, [format, getModifiersKey, primaryKeyIdentifier, selectedTool, runSearch]);
 
   useEffect(() => {
     if (defaultDatabase && !databaseInstance.current) {
       handleChangeDatabase(defaultDatabase);
     }
-  }, [databases, defaultDatabase, handleChangeDatabase, nucleus]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [defaultDatabase]);
 
-  const tableData = useMemo(() => {
-    return prepareData(result.data);
-  }, [result.data]);
+  const tableData = useMemo(() => prepareData(result.data), [result.data]);
 
   const core = useCore();
   const resurrectHandler = useCallback(
@@ -408,11 +465,6 @@ function DatabasePanelInner({
       },
     });
   }, [dispatch]);
-  const searchByStructureHandler = (idCodeValue: string) => {
-    const molecule = Molecule.fromIDCode(idCodeValue);
-    const atoms = molecule.getAllAtoms();
-    setIdCode(atoms > 0 ? idCodeValue : '');
-  };
 
   return (
     <TablePanel isFlipped={isFlipped}>
@@ -425,13 +477,14 @@ function DatabasePanelInner({
             keywords={keywords}
             result={result}
             total={databaseInstance.current?.data.length || 0}
-            onKeywordsChange={(options) =>
-              setKeywords((prevKeywords) => ({ ...prevKeywords, ...options }))
-            }
+            onKeywordsChange={handleKeywordsChange}
             onSettingClick={settingsPanelHandler}
             onStructureClick={openSearchByStructure}
             onDatabaseChange={handleChangeDatabase}
             onRemoveAll={removeAllHandler}
+            onNucleiChange={handleNucleusChange}
+            availableNuclei={availableNuclei}
+            selectedNucleus={selectedNucleus}
           />
           {isOpenSearchByStructure && (
             <DatabaseStructureSearchModal
@@ -491,7 +544,7 @@ export default function PeaksPanel() {
     data.filter((datum) => datum.enabled),
   ) as Databases;
 
-  if (!activeTab || displayerMode !== '1D') {
+  if (displayerMode !== '1D') {
     return (
       <PanelNoData>
         Databases are only available when 1D experimental spectrum is displayed.
@@ -501,7 +554,7 @@ export default function PeaksPanel() {
   }
   return (
     <MemoizedDatabasePanel
-      nucleus={activeTab}
+      nucleus={activeTab || undefined}
       selectedTool={selectedTool}
       databases={databases}
       defaultDatabase={defaultDatabase}

--- a/src/component/panels/databasePanel/DatabaseSearchOptions.tsx
+++ b/src/component/panels/databasePanel/DatabaseSearchOptions.tsx
@@ -26,10 +26,13 @@ interface DatabaseSearchOptionsProps {
   result: DatabaseSearchResultEntry;
   idCode?: string;
   total: number;
+  availableNuclei: string[];
+  selectedNucleus?: string;
   onKeywordsChange: (k: Partial<DatabaseSearchKeywords>) => void;
   onSettingClick: () => void;
   onStructureClick: ToolbarItemProps['onClick'];
   onDatabaseChange: (databaseKey: string) => void;
+  onNucleiChange: (nucleus: string) => void;
   onRemoveAll: () => void;
 }
 
@@ -41,35 +44,41 @@ export function DatabaseSearchOptions(props: DatabaseSearchOptionsProps) {
     result,
     idCode,
     total,
+    availableNuclei,
+    selectedNucleus,
     onKeywordsChange,
     onSettingClick,
     onStructureClick,
     onDatabaseChange,
+    onNucleiChange,
     onRemoveAll,
   } = props;
 
   const { handleChangeOption } = useToolsFunctions();
   const {
     view: {
-      spectra: { showSimilarityTree },
+      spectra: { showSimilarityTree, activeTab },
     },
     toolOptions: { selectedTool },
   } = useChartData();
   const dispatch = useDispatch();
-  function enableFilterHandler(flag: any) {
-    const tool = !flag ? options.zoom.id : options.databaseRangesSelection.id;
+
+  function enableFilterHandler() {
+    const tool =
+      selectedTool === options.databaseRangesSelection.id
+        ? options.zoom.id
+        : options.databaseRangesSelection.id;
     handleChangeOption(tool);
   }
 
-  function handleSearch(input: any) {
-    if (typeof input === 'string' || input === -1) {
-      const solvent = String(input);
-      onKeywordsChange({ solvent });
-    } else {
-      onKeywordsChange({
-        searchKeywords: input.target.value,
-      });
-    }
+  function handleSolventChange(value: string | number) {
+    onKeywordsChange({ solvent: String(value) });
+  }
+
+  function handleKeywordsInputChange(
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) {
+    onKeywordsChange({ searchKeywords: event.target.value });
   }
 
   function clearHandler() {
@@ -80,10 +89,12 @@ export function DatabaseSearchOptions(props: DatabaseSearchOptionsProps) {
     dispatch({ type: 'TOGGLE_SIMILARITY_TREE' });
   }
 
+  const nucleusItems = availableNuclei.map((n) => ({ key: n, label: n }));
+
   return (
     <>
       <PanelHeader
-        onClickSettings={() => onSettingClick()}
+        onClickSettings={onSettingClick}
         current={result.data.length}
         total={total || 0}
       >
@@ -110,21 +121,35 @@ export function DatabaseSearchOptions(props: DatabaseSearchOptionsProps) {
             placeholder="Select database"
             defaultValue={defaultDatabase}
           />
+
+          {!activeTab && nucleusItems.length > 0 && (
+            <Select
+              style={{ flex: 2, marginLeft: '5px' }}
+              items={nucleusItems}
+              itemTextField="label"
+              itemValueField="key"
+              onChange={onNucleiChange}
+              value={selectedNucleus}
+              placeholder="Select nucleus"
+            />
+          )}
+
           <Select
             style={{ flex: 4, margin: '0px 5px' }}
             items={result.solvents}
             placeholder="Solvent"
-            onChange={handleSearch}
+            onChange={handleSolventChange}
             value={keywords.solvent}
           />
         </div>
       </PanelHeader>
+
       <div style={{ display: 'flex', justifyContent: 'space-between' }}>
         <ToolbarButton
           tooltip="Filter by select ranges"
           icon={<FaICursor />}
           active={selectedTool === options.databaseRangesSelection.id}
-          onClick={enableFilterHandler}
+          onClick={() => enableFilterHandler()}
         />
 
         <Input
@@ -135,7 +160,7 @@ export function DatabaseSearchOptions(props: DatabaseSearchOptionsProps) {
           type="text"
           debounceTime={250}
           placeholder="Search for parameter..."
-          onChange={handleSearch}
+          onChange={handleKeywordsInputChange}
           onClear={clearHandler}
           canClear
         />

--- a/src/component/reducer/actions/DatabaseActions.ts
+++ b/src/component/reducer/actions/DatabaseActions.ts
@@ -35,6 +35,20 @@ interface ResurrectSpectrumFromJCAMP extends BaseResurrectSpectrum {
   spectra: Spectrum[];
 }
 
+const DEFAULT_DATABASE_SPECTRUM_DOMAINS: Record<
+  string,
+  { from: number; to: number }
+> = {
+  '1H': {
+    from: -1,
+    to: 13,
+  },
+  '13C': {
+    from: -5,
+    to: 245,
+  },
+} as const;
+
 type ResurrectSpectrumFromRangesOrSignalsAction = ActionType<
   'RESURRECTING_SPECTRUM_FROM_SIGNALS_OR_RANGES',
   BaseResurrectSpectrum
@@ -110,6 +124,10 @@ function handleResurrectSpectrumFromJCAMP(
     }
   }
 
+  if (!draft.view.spectra.activeTab) {
+    draft.view.spectra.activeTab = spectra1D[0].info.nucleus;
+  }
+
   updateDomain(draft);
 
   const active1DSpectra = getSpectraByNucleus(
@@ -126,10 +144,8 @@ function handleResurrectSpectrumFromRangesOrSignals(
   draft: Draft<State>,
   action: ResurrectSpectrumFromRangesOrSignalsAction,
 ) {
-  const {
-    spectra: { activeTab: nucleus },
-  } = draft.view;
   const { databaseEntry, molfile } = action.payload;
+  const nucleus = draft.view.spectra.activeTab || databaseEntry.nucleus;
   const {
     ranges,
     signals,
@@ -154,6 +170,9 @@ function handleResurrectSpectrumFromRangesOrSignals(
     } = activeSpectrum;
     options = { from: x[0], to: x.at(-1) };
     info = { ...spectrumInfo, ...info };
+  } else {
+    const domain = DEFAULT_DATABASE_SPECTRUM_DOMAINS[nucleus || '1H'];
+    options = { ...domain };
   }
 
   let resurrectedSpectrum: Spectrum | null | undefined = null;
@@ -179,6 +198,10 @@ function handleResurrectSpectrumFromRangesOrSignals(
   const filterDatabaseEntryInfo = filterDatabaseInfoEntry(databaseEntry);
   resurrectedSpectrum.customInfo = filterDatabaseEntryInfo;
   draft.data.push(resurrectedSpectrum);
+
+  if (!draft.view.spectra.activeTab) {
+    draft.view.spectra.activeTab = resurrectedSpectrum.info.nucleus;
+  }
 
   updateDomain(draft);
 


### PR DESCRIPTION
When no spectrum is active, the database panel now displays a select listing the nuclei available in the chosen database, instead of requiring a spectrum to determine the nucleus.

If the database only exposes a single nucleus, it is selected automatically.

refactor: database options