### PR TITLE
 fix(export): prevent crashes during export size validation

### DIFF
--- a/src/component/elements/export/ExportOptionsModal.tsx
+++ b/src/component/elements/export/ExportOptionsModal.tsx
@@ -1,4 +1,5 @@
-import { DialogFooter } from '@blueprintjs/core';
+import { Callout, DialogFooter } from '@blueprintjs/core';
+import { revalidateLogic } from '@tanstack/react-form';
 import { useMemo } from 'react';
 import { AppForm, Button, useForm } from 'react-science/ui';
 import { z } from 'zod/v4';
@@ -52,6 +53,8 @@ function InnerExportOptionsModal(props: InnerExportOptionsModalProps) {
     validators: {
       onDynamic: validator,
     },
+    // onDynamic validators are ignored by the default validation logic
+    validationLogic: revalidateLogic({ mode: 'change' }),
     onSubmit: ({ value: { values } }) => {
       const parsedValues = exportSettingsValidation.parse(values);
       onExportOptionsChange(parsedValues);
@@ -69,6 +72,34 @@ function InnerExportOptionsModal(props: InnerExportOptionsModalProps) {
     >
       <AppForm form={form} layout="inline">
         <StyledDialogBody>
+          <form.Subscribe
+            selector={(state) =>
+              Array.from(
+                new Set(
+                  Object.values(state.errorMap.onDynamic ?? {})
+                    .flat()
+                    .map((error) => error?.message)
+                    .filter((message) => typeof message === 'string'),
+                ),
+              )
+            }
+          >
+            {(messages) =>
+              messages.length > 0 && (
+                <Callout
+                  intent="danger"
+                  title="Invalid export options"
+                  style={{ marginBottom: 10 }}
+                >
+                  <ul style={{ margin: 0, paddingInlineStart: '1.2em' }}>
+                    {messages.map((message) => (
+                      <li key={message}>{message}</li>
+                    ))}
+                  </ul>
+                </Callout>
+              )
+            }
+          </form.Subscribe>
           <ExportFields form={form} fields="values" />
         </StyledDialogBody>
         <DialogFooter

--- a/src/component/elements/export/useExportConfigurer.tsx
+++ b/src/component/elements/export/useExportConfigurer.tsx
@@ -12,6 +12,11 @@ export function useExportConfigurer(options: ExportSettings) {
   const refSize = useRef({ width, height, dpi });
   const previousUnit = useDeferredValue(unit);
 
+  function resetSize(newOptions: ExportSettings) {
+    const { width, height, dpi } = getExportOptions(newOptions);
+    refSize.current = { width, height, dpi };
+  }
+
   function changeSize(
     value: number,
     target: 'width' | 'height',
@@ -65,5 +70,6 @@ export function useExportConfigurer(options: ExportSettings) {
     changeUnit,
     changeSize,
     enableAspectRatio,
+    resetSize,
   };
 }

--- a/src/component/modal/setting/tanstack_general_settings/tabs/export_tab.fields.tsx
+++ b/src/component/modal/setting/tanstack_general_settings/tabs/export_tab.fields.tsx
@@ -159,6 +159,8 @@ export const ExportFields = withFieldGroup({
           }}
         >
           {({ mode, layout, unit }) => {
+            const minSize = unit === 'px' ? 1 : 0;
+
             switch (mode) {
               case 'basic':
                 return (
@@ -203,7 +205,7 @@ export const ExportFields = withFieldGroup({
                       {({ NumericInput }) => (
                         <NumericInput
                           label="Width"
-                          min={0}
+                          min={minSize}
                           rightElement={<Tag>{unit}</Tag>}
                         />
                       )}
@@ -216,7 +218,7 @@ export const ExportFields = withFieldGroup({
                       {({ NumericInput }) => (
                         <NumericInput
                           label="Height"
-                          min={0}
+                          min={minSize}
                           rightElement={<Tag>{unit}</Tag>}
                         />
                       )}

--- a/src/component/modal/setting/tanstack_general_settings/tabs/export_tab.fields.tsx
+++ b/src/component/modal/setting/tanstack_general_settings/tabs/export_tab.fields.tsx
@@ -14,7 +14,14 @@ import {
   getExportOptions,
 } from '../../../../elements/export/utilities/getExportOptions.js';
 import { pageSizes } from '../../../../elements/print/pageSize.js';
-import { exportSettingsValidation } from '../validation/export_tab_validation.js';
+import {
+  MAX_DPI,
+  MIN_DPI,
+  dpiField,
+  exportSettingsDecoder,
+  exportSettingsValidation,
+  sizeField,
+} from '../validation/export_tab_validation.js';
 import { defaultGeneralSettingsFormValues } from '../validation.js';
 
 type Mode = 'basic' | 'advance';
@@ -48,31 +55,11 @@ const layoutItems: Array<SelectItem<Layout>> = [
   { value: 'landscape', label: 'Landscape' },
 ];
 
-function safeNumber(value: number) {
-  if (Number.isNaN(value)) value = 1;
-  else if (value <= 0) value = 1;
+/** Returns null for values the schema rejects */
+function parsePositiveNumber(str: string) {
+  const value = Number(str);
+  if (!Number.isFinite(value) || value <= 0) return null;
   return value;
-}
-
-function safeStringNumber(str: string, onInvalid: (str: string) => void) {
-  let isInvalid = false;
-  let value = Number(str);
-  if (Number.isNaN(value)) {
-    value = 1;
-    isInvalid = true;
-  }
-  if (value <= 0) {
-    value = 1;
-    isInvalid = true;
-  }
-
-  if (!isInvalid) {
-    const result = String(value);
-    onInvalid(result);
-    return result;
-  }
-
-  return str;
 }
 
 export const ExportFields = withFieldGroup({
@@ -81,63 +68,56 @@ export const ExportFields = withFieldGroup({
     const inputValues = useSelector(group.store, (s) => s.values);
 
     const outputValues = useMemo(() => {
-      return exportSettingsValidation.decode(inputValues);
+      return exportSettingsDecoder.decode(inputValues);
     }, [inputValues]);
 
     const advancedTransforms = useExportConfigurer(outputValues);
 
     function onModeChange({ value }: { value: Mode }) {
-      const newOptions = getExportDefaultOptionsByMode(value);
+      const defaultOptions = getExportDefaultOptionsByMode(value);
+      const newOptions = exportSettingsValidation.encode(defaultOptions);
 
       for (const [key, value] of Object.entries(newOptions)) {
         group.setFieldValue(key as keyof typeof newOptions, value, {
           dontRunListeners: true,
         });
       }
+      // keep the aspect ratio if the options is activated
+      advancedTransforms.resetSize(defaultOptions);
     }
 
     function onChangeUnit({ value }: { value: Unit }) {
       const { width, height } = advancedTransforms.changeUnit({ unit: value });
-      group.setFieldValue('width', String(safeNumber(width)), {
+      group.setFieldValue('width', String(width), {
         dontRunListeners: true,
       });
-      group.setFieldValue('height', String(safeNumber(height)), {
+      group.setFieldValue('height', String(height), {
         dontRunListeners: true,
       });
     }
 
     function onWidthChange({ value }: { value: string }) {
-      value = safeStringNumber(value, (width) =>
-        group.setFieldValue('width', width, { dontRunListeners: true }),
-      );
+      const width = parsePositiveNumber(value);
+      if (width === null) return;
 
-      const height = advancedTransforms.changeSize(
-        Number(value),
-        'height',
-        'width',
-      );
+      const height = advancedTransforms.changeSize(width, 'height', 'width');
       if (!advancedTransforms.isAspectRatioEnabled) {
         return;
       }
-      group.setFieldValue('height', String(safeNumber(height)), {
+      group.setFieldValue('height', String(height), {
         dontRunListeners: true,
       });
     }
 
     function onHeightChange({ value }: { value: string }) {
-      value = safeStringNumber(value, (height) =>
-        group.setFieldValue('height', height, { dontRunListeners: true }),
-      );
+      const height = parsePositiveNumber(value);
+      if (height === null) return;
 
-      const width = advancedTransforms.changeSize(
-        Number(value),
-        'width',
-        'height',
-      );
+      const width = advancedTransforms.changeSize(height, 'width', 'height');
       if (!advancedTransforms.isAspectRatioEnabled) {
         return;
       }
-      group.setFieldValue('width', String(safeNumber(width)), {
+      group.setFieldValue('width', String(width), {
         dontRunListeners: true,
       });
     }
@@ -146,14 +126,14 @@ export const ExportFields = withFieldGroup({
       if (inputValues.mode !== 'advance') return;
       if (inputValues.unit !== 'px') return;
 
-      value = safeStringNumber(value, (dpi) =>
-        group.setFieldValue('dpi', dpi, { dontRunListeners: true }),
-      );
-      const { width, height } = advancedTransforms.changeDPI(Number(value));
-      group.setFieldValue('width', String(safeNumber(width)), {
+      const dpi = parsePositiveNumber(value);
+      if (dpi === null || dpi < MIN_DPI || dpi > MAX_DPI) return;
+
+      const { width, height } = advancedTransforms.changeDPI(dpi);
+      group.setFieldValue('width', String(width), {
         dontRunListeners: true,
       });
-      group.setFieldValue('height', String(safeNumber(height)), {
+      group.setFieldValue('height', String(height), {
         dontRunListeners: true,
       });
     }
@@ -218,11 +198,12 @@ export const ExportFields = withFieldGroup({
                     <AppField
                       name="width"
                       listeners={{ onChange: onWidthChange }}
+                      validators={{ onChange: sizeField }}
                     >
                       {({ NumericInput }) => (
                         <NumericInput
                           label="Width"
-                          min={1}
+                          min={0}
                           rightElement={<Tag>{unit}</Tag>}
                         />
                       )}
@@ -230,11 +211,12 @@ export const ExportFields = withFieldGroup({
                     <AppField
                       name="height"
                       listeners={{ onChange: onHeightChange }}
+                      validators={{ onChange: sizeField }}
                     >
                       {({ NumericInput }) => (
                         <NumericInput
                           label="Height"
-                          min={1}
+                          min={0}
                           rightElement={<Tag>{unit}</Tag>}
                         />
                       )}
@@ -246,8 +228,14 @@ export const ExportFields = withFieldGroup({
             }
           }}
         </Subscribe>
-        <AppField name="dpi" listeners={{ onChange: onDPIChange }}>
-          {({ NumericInput }) => <NumericInput label="DPI" />}
+        <AppField
+          name="dpi"
+          listeners={{ onChange: onDPIChange }}
+          validators={{ onChange: dpiField }}
+        >
+          {({ NumericInput }) => (
+            <NumericInput label="DPI" min={MIN_DPI} max={MAX_DPI} />
+          )}
         </AppField>
         <AppField name="useDefaultSettings">
           {({ Checkbox }) => (

--- a/src/component/modal/setting/tanstack_general_settings/validation/export_tab_validation.ts
+++ b/src/component/modal/setting/tanstack_general_settings/validation/export_tab_validation.ts
@@ -3,6 +3,12 @@ import { units } from '@zakodium/nmrium-core';
 import { coerceNumberInput } from 'react-science/ui';
 import { z } from 'zod';
 
+import { convert, convertToPixels } from '../../../../elements/export/units.js';
+import {
+  MAX_CANVAS_AREA,
+  MAX_CANVAS_SIDE,
+} from '../../../../utility/export.ts';
+
 const exportSizes: PageSizeName[] = [
   'Letter',
   'Legal',
@@ -18,40 +24,106 @@ const exportSizes: PageSizeName[] = [
 ];
 const exportLayouts: Layout[] = ['portrait', 'landscape'];
 
-/**
- * @see {import("@zakodium/nmrium-core").BaseExportSettings}
- */
-const baseExportSettings = z.object({
-  useDefaultSettings: z.boolean(),
-  dpi: coerceNumberInput(),
-});
+export const MIN_DPI = 1;
+export const MAX_DPI = 1200;
 
-/**
- * @see {import("@zakodium/nmrium-core").BasicExportSettings}
- */
-const basicExportSettings = z.object({
-  mode: z.literal('basic'),
-  ...baseExportSettings.shape,
-  size: z.enum(exportSizes),
-  layout: z.enum(exportLayouts),
-});
-/**
- * @see {import("@zakodium/nmrium-core").AdvanceExportSettings}
- */
-const advancedExportSettings = z.object({
-  mode: z.literal('advance'),
-  ...baseExportSettings.shape,
-  width: coerceNumberInput(),
-  height: coerceNumberInput(),
-  unit: z.enum(units.map((u) => u.unit)),
-});
+const formatNumber = (value: number) => value.toLocaleString('en-US');
+
+/** Sizes are unit-relative (m, in, cm, px...), so the only unit-agnostic invariant is being positive. */
+export const sizeField = coerceNumberInput(z.number().positive());
+export const dpiField = coerceNumberInput(
+  z.number().int().min(MIN_DPI).max(MAX_DPI),
+);
+
+type NumberField = ReturnType<typeof coerceNumberInput>;
+type Side = 'width' | 'height';
+
+const sides: Side[] = ['width', 'height'];
+
+/** @see {import("@zakodium/nmrium-core").BasicExportSettings} */
+function basicSettings(dpi: NumberField) {
+  return z.object({
+    mode: z.literal('basic'),
+    useDefaultSettings: z.boolean(),
+    dpi,
+    size: z.enum(exportSizes),
+    layout: z.enum(exportLayouts),
+  });
+}
+
+/** @see {import("@zakodium/nmrium-core").AdvanceExportSettings} */
+function advancedSettings(size: NumberField, dpi: NumberField) {
+  return z.object({
+    mode: z.literal('advance'),
+    useDefaultSettings: z.boolean(),
+    dpi,
+    width: size,
+    height: size,
+    unit: z.enum(units.map((u) => u.unit)),
+  });
+}
+
+type AdvancedSettings = z.output<ReturnType<typeof advancedSettings>>;
+
+/** A canvas the browser cannot allocate makes the export fail, so the real limit is the size in pixels. */
+function getSizeErrors(settings: AdvancedSettings) {
+  const { unit, dpi, width, height } = settings;
+  const pixels = {
+    width: convertToPixels(width, unit, dpi, { precision: 0 }),
+    height: convertToPixels(height, unit, dpi, { precision: 0 }),
+  };
+
+  function inCurrentUnit(px: number) {
+    if (unit === 'px') return `${formatNumber(px)} px`;
+    return `${convert(px, 'px', unit, dpi, { precision: 2 })} ${unit}`;
+  }
+
+  const errors: Partial<Record<Side, string>> = {};
+
+  for (const side of sides) {
+    if (pixels[side] < 1) {
+      errors[side] = `Too small to export. Use at least ${inCurrentUnit(1)}.`;
+    } else if (pixels[side] > MAX_CANVAS_SIDE) {
+      errors[side] =
+        `Too large to export. Use at most ${inCurrentUnit(MAX_CANVAS_SIDE)}.`;
+    }
+  }
+
+  const hasSideError = sides.some((side) => errors[side]);
+  if (!hasSideError && pixels.width * pixels.height > MAX_CANVAS_AREA) {
+    const message = `The export would be ${formatNumber(pixels.width)} x ${formatNumber(pixels.height)} pixels, which is too large. Try a smaller size or a lower DPI.`;
+    errors.width = message;
+    errors.height = message;
+  }
+
+  return errors;
+}
 
 /**
  * @see {import("@zakodium/nmrium-core").ExportSettings}
  */
 export const exportSettingsValidation = z.discriminatedUnion('mode', [
-  basicExportSettings,
-  advancedExportSettings,
+  basicSettings(dpiField),
+  advancedSettings(sizeField, dpiField).check(({ value, issues }) => {
+    const errors = getSizeErrors(value);
+
+    for (const side of sides) {
+      const message = errors[side];
+      if (!message) continue;
+
+      issues.push({
+        code: 'custom',
+        input: value[side],
+        path: [side],
+        message,
+      });
+    }
+  }),
+]);
+
+export const exportSettingsDecoder = z.discriminatedUnion('mode', [
+  basicSettings(coerceNumberInput()),
+  advancedSettings(coerceNumberInput(), coerceNumberInput()),
 ]);
 
 /**

--- a/src/component/utility/export.ts
+++ b/src/component/utility/export.ts
@@ -139,6 +139,39 @@ interface CreateCanvasByChunksOptions {
   scaleFactor?: number;
 }
 
+/**
+ * Browsers limits.
+ */
+export const MAX_CANVAS_SIDE = 32_767;
+export const MAX_CANVAS_AREA = 268_435_456;
+
+function formatPixels(value: number) {
+  return Math.round(value).toLocaleString('en-US');
+}
+
+/** throw error if canvas size exceeds browsers limits */
+function assertCanvasSize(width: number, height: number) {
+  const size = `${formatPixels(width)} x ${formatPixels(height)} px`;
+
+  if (width < 1 || height < 1) {
+    throw new Error(
+      `Export size is too small: ${size}. Increase the size or the DPI.`,
+    );
+  }
+
+  if (width > MAX_CANVAS_SIDE || height > MAX_CANVAS_SIDE) {
+    throw new Error(
+      `Export size is too large: ${size}. Each side must be at most ${formatPixels(MAX_CANVAS_SIDE)} px. Reduce the size or the DPI.`,
+    );
+  }
+
+  if (width * height > MAX_CANVAS_AREA) {
+    throw new Error(
+      `Export size is too large: ${size} is over the ${formatPixels(MAX_CANVAS_AREA)} px limit. Reduce the size or the DPI.`,
+    );
+  }
+}
+
 interface DrawImageOptions {
   context: OffscreenCanvasRenderingContext2D;
   chunkX: number;
@@ -203,6 +236,7 @@ async function createCanvasByChunks(
   context: OffscreenCanvasRenderingContext2D;
 }> {
   const { width, height, scaleFactor = 1, chunkSize = 512 } = options;
+  assertCanvasSize(width, height);
   const canvas = new OffscreenCanvas(width, height);
   canvas.width = width;
   canvas.height = height;


### PR DESCRIPTION
Switching to Advanced mode could crash the app, clearing a size field could break the aspect ratio, and oversized exports failed silently with a cryptic error.

- Fix crash when applying default values in Advanced mode
- Do not reset empty/invalid fields to 1
- Validate against the final rendered pixel size, not the raw input values, and reject sizes the browser cannot handle: less than 1 px per side, more than 32,767 px per side, or more than 268,435,456 px total
- Fix broken size validation logic
- Show clear error messages in the export dialog