### PR TITLE
fix(database): avoid cloning Immer proxies during spectrum resurrection

### DIFF
--- a/src/component/reducer/actions/DatabaseActions.ts
+++ b/src/component/reducer/actions/DatabaseActions.ts
@@ -2,6 +2,7 @@ import type { Info1D } from '@zakodium/nmr-types';
 import type { Spectrum } from '@zakodium/nmrium-core';
 import { isSpectrum1D } from '@zakodium/nmrium-core';
 import type { Draft } from 'immer';
+import { current } from 'immer';
 import type { DatabaseNMREntry } from 'nmr-processing';
 
 import {
@@ -157,10 +158,10 @@ function handleResurrectSpectrumFromRangesOrSignals(
   if (isSpectrum1D(activeSpectrum)) {
     const {
       data: { x },
-      info: spectrumInfo,
-    } = activeSpectrum;
+      info: activeSpectrumInfo,
+    } = current(activeSpectrum);
     options = { from: x[0], to: x.at(-1) };
-    info = { ...spectrumInfo, ...info };
+    info = { ...activeSpectrumInfo, ...info };
   } else {
     const domain = DEFAULT_DATABASE_SPECTRUM_DOMAINS[nucleus || '1H'];
     options = { ...domain };


### PR DESCRIPTION
The issue introduced in #4254

Database spectrum resurrection copied `info` from an Immer draft. Nested arrays and objects (`first`, `last`, `symbols`, and `varDim`) are draft proxies, which cannot be passed to `structuredClone`.

Create a plain snapshot with `current(activeSpectrum)` before copying its metadata, allowing `initiateDatum1D` to preserve `originalInfo` safely.